### PR TITLE
feat/revoke-property

### DIFF
--- a/sources/htf.move
+++ b/sources/htf.move
@@ -177,6 +177,9 @@ module htf::main {
     federation.governance.trusted_constraints.add_constraint(property_name, constraint) ;
   }
 
+
+  // TODO should be removed
+  // This has left due to of compatilibity with the rust abstraction
   public fun remove_trusted_property(
     federation : &mut Federation,
     cap : &RootAuthorityCap,
@@ -193,6 +196,13 @@ module htf::main {
       id : object::new(ctx),
       federation_id : self.federation_id(),
     }
+  }
+
+  // Revoke trusted property by setting the validity to a specific time
+  public fun revoke_trusted_property(federation : &mut Federation, cap : &RootAuthorityCap, property_name : TrustedPropertyName, valid_to_ms : u64) {
+    assert!(cap.federation_id == federation.federation_id(), EUnauthorizedWrongFederation);
+    let property_constraint = federation.governance.trusted_constraints.data_mut().get_mut(&property_name);
+    property_constraint.revoke_constraint(valid_to_ms);
   }
 
   /// Creates a new attest capability
@@ -238,8 +248,9 @@ module htf::main {
   public fun issue_permission_to_accredit(federation : &mut Federation, cap : &AccreditCap,  receiver : ID, want_property_constraints : vector<TrustedPropertyConstraint>,  ctx : &mut TxContext) {
       assert!(cap.federation_id == federation.federation_id(), EUnauthorizedWrongFederation);
 
+      let current_time_ms = ctx.epoch_timestamp_ms();
       let permissions_to_accredit = federation.find_permissions_to_accredit(&ctx.sender().to_id());
-      assert!(permissions_to_accredit.are_constraints_permitted(&want_property_constraints), EUnauthorizedInsufficientAccreditation);
+      assert!(permissions_to_accredit.are_constraints_permitted(&want_property_constraints, current_time_ms), EUnauthorizedInsufficientAccreditation);
 
       let mut trusted_constraints :VecMap<TrustedPropertyName, TrustedPropertyConstraint> =  vec_map::empty();
       let want_property_constraints_len = vector::length<TrustedPropertyConstraint>(&want_property_constraints);
@@ -267,8 +278,9 @@ module htf::main {
   public fun issue_permission_to_attest(federation : &mut Federation, cap : &AttestCap, receiver : ID, wanted_constraints: vector<TrustedPropertyConstraint>, ctx : &mut TxContext) {
     assert!(cap.federation_id == federation.federation_id(), EUnauthorizedWrongFederation);
 
+    let current_time_ms = ctx.epoch_timestamp_ms();
     let permissions_to_accredit = federation.find_permissions_to_accredit(&ctx.sender().to_id());
-    assert!(permissions_to_accredit.are_constraints_permitted(&wanted_constraints), EUnauthorizedInsufficientAccreditation);
+    assert!(permissions_to_accredit.are_constraints_permitted(&wanted_constraints, current_time_ms), EUnauthorizedInsufficientAccreditation);
 
     let permission = permission_to_attest::new_permission_to_attest(
       federation.federation_id(), trusted_constraint::to_map_of_constraints(wanted_constraints), ctx
@@ -287,6 +299,7 @@ module htf::main {
   }
 
   public fun revoke_permission_to_attest(federation : &mut Federation, cap : &AttestCap, user_id : &ID,  permission_id : &ID, ctx : &mut TxContext) {
+    let current_time_ms = ctx.epoch_timestamp_ms();
     assert!(cap.federation_id == federation.federation_id(), EUnauthorizedWrongFederation);
 
     let remover_permissions = federation.find_permissions_to_attest(&ctx.sender().to_id());
@@ -298,7 +311,7 @@ module htf::main {
     // Make suere that the sender has the right to revoke the permission
     let permission_to_revoke = &users_attest_permissions.permisssions()[permission_to_revoke_idx.extract()];
     let (_, constraints) = (*permission_to_revoke.constraints()).into_keys_values() ;
-    assert!(remover_permissions.are_constraints_permitted(&constraints), EUnauthorizedInsufficientAttestation);
+    assert!(remover_permissions.are_constraints_permitted(&constraints, current_time_ms), EUnauthorizedInsufficientAttestation);
 
     // Remove the permission
     let users_attest_permissions =  federation.governance.attesters.get_mut(user_id);
@@ -308,7 +321,6 @@ module htf::main {
 
   public fun revoke_permission_to_accredit(federation : &mut Federation, cap : &AccreditCap, user_id : &ID,  permission_id : &ID, ctx : &mut TxContext) {
     assert!(cap.federation_id == federation.federation_id(), EUnauthorizedWrongFederation);
-
     let remover_permissions = federation.find_permissions_to_accredit(&ctx.sender().to_id());
 
     let users_accredit_permissions = federation.find_permissions_to_accredit(user_id);
@@ -317,8 +329,9 @@ module htf::main {
 
     // make suere that the sender has the right to revoke the permission
     let permission_to_revoke = &users_accredit_permissions.permisssions()[permission_to_revoke_idx.extract()];
+    let current_time_ms   = ctx.epoch_timestamp_ms();
     let (_, constraints) = (*permission_to_revoke.constriants()).into_keys_values() ;
-    assert!(remover_permissions.are_constraints_permitted(&constraints), EUnauthorizedInsufficientAccreditation);
+    assert!(remover_permissions.are_constraints_permitted(&constraints, current_time_ms), EUnauthorizedInsufficientAccreditation);
 
     // Remove the permission
     let users_accredit_permissions =  federation.governance.accreditors.get_mut(user_id);
@@ -336,7 +349,7 @@ module htf::main {
       assert!(cap.federation_id == federation.federation_id(), EUnauthorizedWrongFederation);
 
       let permissions_to_attest = federation.find_permissions_to_attest(&ctx.sender().to_id());
-      assert!(permissions_to_attest.are_values_permitted(&trusted_properties), EUnauthorizedInsufficientAttestation);
+      assert!(permissions_to_attest.are_values_permitted(&trusted_properties, ctx.epoch_timestamp_ms()), EUnauthorizedInsufficientAttestation);
 
       let creds = new_credential(trusted_properties, valid_from_ts_ms, valid_until_ts_ms, receiver, ctx);
       federation.governance.credentials_state.insert(creds.id.to_inner(), new_credential_state());
@@ -344,9 +357,11 @@ module htf::main {
       transfer::transfer(creds, receiver.to_address());
   }
 
-  public fun validate_trusted_properties(self : &Federation, issuer_id : &ID, trusted_properties: VecMap<TrustedPropertyName, TrustedPropertyValue>) {
-    // check if every property belongs to the federation
+  public fun validate_trusted_properties(self : &Federation, issuer_id : &ID, trusted_properties: VecMap<TrustedPropertyName, TrustedPropertyValue>, ctx : &mut TxContext) {
+    // ? Should the user of trust framework be allowed to use any timestamp to validate the properites at any point in time?
+    let current_time_ms = ctx.epoch_timestamp_ms();
     let property_names = trusted_properties.keys();
+
     let mut idx = 0;
     while (idx < property_names.length()) {
       let property_name = property_names[idx];
@@ -359,14 +374,15 @@ module htf::main {
     // then check if names and values are permitted for given issuer
     let issuer_permissions_to_attest = self.find_permissions_to_attest(issuer_id);
     assert!(
-      issuer_permissions_to_attest.are_values_permitted(&trusted_properties),
+      issuer_permissions_to_attest.are_values_permitted(&trusted_properties, current_time_ms),
       EInvalidIssuerInsufficientAttestation,
     );
   }
 
   public fun validate_credential(self : &Federation, credential : &Credential, ctx : &mut TxContext) {
+    let current_time_ms = ctx.epoch_timestamp_ms();
     assert!(
-      self.governance.trusted_constraints.are_properties_correct(credential.trusted_properties()),
+      self.governance.trusted_constraints.are_properties_correct(credential.trusted_properties(), current_time_ms),
       EInvalidProperty,
     );
     assert!(
@@ -386,7 +402,7 @@ module htf::main {
 
     let issuer_permissions_to_attest = self.find_permissions_to_attest(credential.issued_by());
     assert!(
-      issuer_permissions_to_attest.are_values_permitted(credential.trusted_properties()),
+      issuer_permissions_to_attest.are_values_permitted(credential.trusted_properties(), current_time_ms),
       EInvalidIssuerInsufficientAttestation,
     );
   }

--- a/sources/permission_to_accredit.move
+++ b/sources/permission_to_accredit.move
@@ -44,11 +44,11 @@ module htf::permission_to_accredit {
     }
   }
 
-  public(package) fun are_constraints_permitted(self : &PermissionsToAccredit, constraints: &vector<TrustedPropertyConstraint> ) :bool {
+  public(package) fun are_constraints_permitted(self : &PermissionsToAccredit, constraints: &vector<TrustedPropertyConstraint>, current_time_ms : u64) :bool {
     let mut idx = 0;
     while ( idx < constraints.length()  ) {
         let constraint = constraints[idx];
-        if ( ! self.is_constraint_permitted(&constraint)  )  {
+        if ( ! self.is_constraint_permitted(&constraint, current_time_ms)  )  {
           return false
         };
         idx = idx + 1;
@@ -57,7 +57,7 @@ module htf::permission_to_accredit {
   }
 
 
-  public(package) fun is_constraint_permitted(self : &PermissionsToAccredit, constraint : &TrustedPropertyConstraint) :  bool {
+  public(package) fun is_constraint_permitted(self : &PermissionsToAccredit, constraint : &TrustedPropertyConstraint, current_time_ms : u64) :  bool {
     let len_permissions_to_accredit = self.permissions.length();
     let mut idx_permissions_to_accredit = 0;
     let mut want_constraints : vector<TrustedPropertyValue> = utils::copy_vector(constraint.allowed_values().keys());
@@ -74,7 +74,7 @@ module htf::permission_to_accredit {
       let mut idx_want_constraints = 0;
       while (idx_want_constraints < len_want_constraints ) {
         let constraint_value = want_constraints[idx_want_constraints];
-        if ( maybe_property_constraint.borrow().matches_value(&constraint_value) ) {
+        if ( maybe_property_constraint.borrow().matches_value(&constraint_value, current_time_ms) ) {
           want_constraints.remove(idx_want_constraints);
           len_want_constraints = len_want_constraints - 1;
         };

--- a/sources/permission_to_attest.move
+++ b/sources/permission_to_attest.move
@@ -57,7 +57,7 @@ module htf::permission_to_attest {
   }
 
   /// checks if all constraints matches the given in Accredidations
-  public(package) fun are_values_permitted(self : &PermissionsToAttest, trusted_properties: &VecMap<TrustedPropertyName, TrustedPropertyValue> ) :bool {
+  public(package) fun are_values_permitted(self : &PermissionsToAttest, trusted_properties: &VecMap<TrustedPropertyName, TrustedPropertyValue>, current_time_ms : u64) :bool {
     let property_names = trusted_properties.keys() ;
     let mut idx_property_names = 0;
 
@@ -65,7 +65,7 @@ module htf::permission_to_attest {
       let property_name = property_names[idx_property_names];
       let property_value = trusted_properties.get(&property_name);
 
-      if (! self.is_value_permitted(&property_name, property_value)  ) {
+      if (! self.is_value_permitted(&property_name, property_value, current_time_ms)  ) {
         return false
       };
 
@@ -76,7 +76,7 @@ module htf::permission_to_attest {
   }
 
 
-  public(package) fun is_value_permitted(self : &PermissionsToAttest, property_name : &TrustedPropertyName, property_value : &TrustedPropertyValue) :  bool {
+  public(package) fun is_value_permitted(self : &PermissionsToAttest, property_name : &TrustedPropertyName, property_value : &TrustedPropertyValue, current_time_ms : u64) :  bool {
     let len_permissions_to_attest = self.permissions.length();
     let mut idx_permissions_to_attest = 0;
 
@@ -87,7 +87,7 @@ module htf::permission_to_attest {
       if ( maybe_property_constraint.is_none()) {
         continue
       };
-      if (maybe_property_constraint.borrow().matches_property(property_name, property_value)) {
+      if (maybe_property_constraint.borrow().matches_property(property_name, property_value, current_time_ms)) {
         return true
       };
       idx_permissions_to_attest = idx_permissions_to_attest + 1;
@@ -97,11 +97,11 @@ module htf::permission_to_attest {
     return false
   }
 
-  public(package) fun are_constraints_permitted(self : &PermissionsToAttest, constraints: &vector<TrustedPropertyConstraint> ) :bool {
+  public(package) fun are_constraints_permitted(self : &PermissionsToAttest, constraints: &vector<TrustedPropertyConstraint>, current_time_ms : u64 ) :bool {
     let mut idx = 0;
     while ( idx < constraints.length()  ) {
         let constraint = constraints[idx];
-        if ( ! self.is_constraint_permitted(&constraint)  )  {
+        if ( ! self.is_constraint_permitted(&constraint, current_time_ms)  )  {
           return false
         };
         idx = idx + 1;
@@ -109,7 +109,7 @@ module htf::permission_to_attest {
     return true
   }
 
-  public(package) fun is_constraint_permitted(self : &PermissionsToAttest, constraint : &TrustedPropertyConstraint) :  bool {
+  public(package) fun is_constraint_permitted(self : &PermissionsToAttest, constraint : &TrustedPropertyConstraint, current_time_ms : u64) :  bool {
     let len_permissions = self.permissions.length();
     let mut idx_permissions = 0;
     let mut want_constraints : vector<TrustedPropertyValue> = utils::copy_vector(constraint.allowed_values().keys());
@@ -126,7 +126,7 @@ module htf::permission_to_attest {
       let mut idx_want_constraints = 0;
       while (idx_want_constraints < len_want_constraints ) {
         let constraint_value = want_constraints[idx_want_constraints];
-        if ( maybe_property_constraint.borrow().matches_value(&constraint_value) ) {
+        if ( maybe_property_constraint.borrow().matches_value(&constraint_value, current_time_ms) ) {
           want_constraints.remove(idx_want_constraints);
           len_want_constraints = len_want_constraints - 1;
         };


### PR DESCRIPTION
# Description of change

add  public API method:
`revoke_propert()`. The method requires the timestamp in milliseconds to set the validity time. The Root Authority can specify any time, because the property should be revoked some day in the future.

## Links to any relevant issues

closes #8 

This change leaves the `remove_property()` method untouched, because of compatibility with the `rust` abstraction. When the rust abstraction is adjusted, it should be removed

## Type of change

- Enhancement (a non-breaking change that adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)


## How the change has been tested

<!-- Describe the tests that you ran to verify your changes. -->

<!-- Make sure to provide instructions for the maintainer as well as any relevant configurations. -->

## Change checklist

<!-- Tick the boxes that are relevant to your changes, and delete any items that are not. -->

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md, if my changes are significant enough
