### PR TITLE
feat: enhance statement revocation functionality

### DIFF
--- a/ith.rs/ith/src/client/full_client.rs
+++ b/ith.rs/ith/src/client/full_client.rs
@@ -209,7 +209,7 @@ where
         &self,
         federation_id: ObjectID,
         statement_name: StatementName,
-        valid_to_ms: u64,
+        valid_to_ms: Option<u64>,
     ) -> TransactionBuilder<RevokeStatement> {
         TransactionBuilder::new(RevokeStatement::new(
             federation_id,

--- a/ith.rs/ith/tests/e2e/test_statements.rs
+++ b/ith.rs/ith/tests/e2e/test_statements.rs
@@ -95,7 +95,7 @@ async fn test_revoke_statement() -> anyhow::Result<()> {
     // Revoke the statement with a specific timestamp
     let revoke_time = 1234567890u64;
     let result = client
-        .revoke_statement(*federation_id.object_id(), statement_name.clone(), revoke_time)
+        .revoke_statement(*federation_id.object_id(), statement_name.clone(), Some(revoke_time))
         .build_and_execute(&client)
         .await;
 


### PR DESCRIPTION
- Added a new error constant `ETimestampMustBeInTheFuture` to handle past timestamps.
- Updated `revoke_statement` and `revoke_statement_at` functions to include a `Clock` parameter for timestamp validation.
- Modified the `valid_to_ms` parameter in the `RevokeStatement` struct to be an `Option<u64>` for better flexibility.
- Adjusted the client code to accommodate the changes in the revocation methods, allowing for optional expiration timestamps.
- Updated tests to reflect the new parameter structure and ensure correct functionality.

# Description of change

<!-- Please write a summary of your changes and why you made them. -->

## Links to any relevant issues

<!-- Be sure to reference any related issues by adding `fixes #issue_number`. -->

## Type of change

<!-- Choose a type of change, and delete any options that are not relevant. -->

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation Fix

## How the change has been tested

<!-- Describe the tests that you ran to verify your changes. -->

<!-- Make sure to provide instructions for the maintainer as well as any relevant configurations. -->

## Change checklist

<!-- Tick the boxes that are relevant to your changes, and delete any items that are not. -->

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md, if my changes are significant enough
