### PR TITLE
Update dependencies to iota v1.7.0 and product-core to v0.8.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,7 +1198,7 @@ checksum = "e47641d3deaf41fb1538ac1f54735925e275eaf3bf4d55c81b137fba797e5cbb"
 [[package]]
 name = "consensus-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "fastcrypto",
  "iota-network-stack",
@@ -1873,7 +1873,7 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 [[package]]
 name = "enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "serde_yaml",
 ]
@@ -2603,7 +2603,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "hierarchies",
- "iota-sdk 1.6.1",
+ "iota-sdk 1.7.0",
  "product_common",
  "tokio",
 ]
@@ -3046,7 +3046,7 @@ dependencies = [
 [[package]]
 name = "iota-adapter-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3073,8 +3073,8 @@ dependencies = [
 
 [[package]]
 name = "iota-config"
-version = "1.6.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anemo",
  "anyhow",
@@ -3137,8 +3137,8 @@ dependencies = [
 
 [[package]]
 name = "iota-enum-compat-util"
-version = "1.6.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "serde_yaml",
 ]
@@ -3146,7 +3146,7 @@ dependencies = [
 [[package]]
 name = "iota-execution"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "iota-adapter-latest",
  "iota-move-natives-latest",
@@ -3163,8 +3163,8 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-common"
-version = "1.6.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "iota-execution",
  "iota-protocol-config",
@@ -3174,8 +3174,8 @@ dependencies = [
 
 [[package]]
 name = "iota-http"
-version = "1.6.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "bytes",
  "http",
@@ -3194,8 +3194,8 @@ dependencies = [
 
 [[package]]
 name = "iota-json"
-version = "1.6.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3211,8 +3211,8 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-api"
-version = "1.6.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -3231,8 +3231,8 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-types"
-version = "1.6.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3265,8 +3265,8 @@ dependencies = [
 
 [[package]]
 name = "iota-keys"
-version = "1.6.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "bip32",
@@ -3286,8 +3286,8 @@ dependencies = [
 
 [[package]]
 name = "iota-macros"
-version = "1.6.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "futures",
  "iota-proc-macros",
@@ -3297,8 +3297,8 @@ dependencies = [
 
 [[package]]
 name = "iota-metrics"
-version = "1.6.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -3324,7 +3324,7 @@ dependencies = [
 [[package]]
 name = "iota-move-natives-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "bcs",
  "better_any",
@@ -3346,8 +3346,8 @@ dependencies = [
 
 [[package]]
 name = "iota-names"
-version = "1.6.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3359,8 +3359,8 @@ dependencies = [
 
 [[package]]
 name = "iota-network-stack"
-version = "1.6.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anemo",
  "bcs",
@@ -3388,8 +3388,8 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc"
-version = "1.6.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -3399,8 +3399,8 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc-macros"
-version = "1.6.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -3412,8 +3412,8 @@ dependencies = [
 
 [[package]]
 name = "iota-package-resolver"
-version = "1.6.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "async-trait",
  "bcs",
@@ -3428,8 +3428,8 @@ dependencies = [
 
 [[package]]
 name = "iota-proc-macros"
-version = "1.6.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "msim-macros",
  "proc-macro2",
@@ -3439,8 +3439,8 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config"
-version = "1.6.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "clap",
  "iota-protocol-config-macros",
@@ -3454,8 +3454,8 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config-macros"
-version = "1.6.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3464,8 +3464,8 @@ dependencies = [
 
 [[package]]
 name = "iota-rest-api"
-version = "1.6.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "axum",
@@ -3494,7 +3494,7 @@ dependencies = [
 [[package]]
 name = "iota-rust-sdk"
 version = "0.0.0"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=93580286f3714248398d17e4481daf608508856a#93580286f3714248398d17e4481daf608508856a"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=d7084eaf0564f4e2381b2e8408ee1f7d51468450#d7084eaf0564f4e2381b2e8408ee1f7d51468450"
 dependencies = [
  "base64ct",
  "bcs",
@@ -3545,8 +3545,8 @@ dependencies = [
 
 [[package]]
 name = "iota-sdk"
-version = "1.6.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3579,8 +3579,8 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-builder"
-version = "1.6.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3596,8 +3596,8 @@ dependencies = [
 
 [[package]]
 name = "iota-types"
-version = "1.6.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anemo",
  "anyhow",
@@ -3662,7 +3662,7 @@ dependencies = [
 [[package]]
 name = "iota-verifier-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "iota-types",
  "move-abstract-interpreter",
@@ -3676,8 +3676,8 @@ dependencies = [
 
 [[package]]
 name = "iota_interaction"
-version = "0.8.2"
-source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.2#9e569ed450559d778c2f75c4e9698effb590449d"
+version = "0.8.3"
+source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.3#259fe697d1246f2f589b97c976f1bc3ee79fae88"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3690,7 +3690,7 @@ dependencies = [
  "fastcrypto-zkp",
  "hex",
  "indexmap 2.11.0",
- "iota-sdk 1.6.1",
+ "iota-sdk 1.7.0",
  "itertools 0.13.0",
  "jsonpath-rust",
  "jsonrpsee",
@@ -3716,8 +3716,8 @@ dependencies = [
 
 [[package]]
 name = "iota_interaction_rust"
-version = "0.8.2"
-source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.2#9e569ed450559d778c2f75c4e9698effb590449d"
+version = "0.8.3"
+source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.3#259fe697d1246f2f589b97c976f1bc3ee79fae88"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3729,8 +3729,8 @@ dependencies = [
 
 [[package]]
 name = "iota_interaction_ts"
-version = "0.8.2"
-source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.2#9e569ed450559d778c2f75c4e9698effb590449d"
+version = "0.8.3"
+source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.3#259fe697d1246f2f589b97c976f1bc3ee79fae88"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4341,7 +4341,7 @@ dependencies = [
 [[package]]
 name = "move-abstract-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "move-binary-format",
  "move-bytecode-verifier-meter",
@@ -4350,12 +4350,12 @@ dependencies = [
 [[package]]
 name = "move-abstract-stack"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "enum-compat-util",
@@ -4369,12 +4369,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4390,7 +4390,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "indexmap 2.11.0",
@@ -4404,7 +4404,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -4419,7 +4419,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-meter"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -4429,7 +4429,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4439,6 +4439,7 @@ dependencies = [
  "move-binary-format",
  "move-core-types",
  "once_cell",
+ "packed_struct",
  "serde",
  "sha2 0.9.9",
  "vfs",
@@ -4448,7 +4449,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4483,7 +4484,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4507,7 +4508,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4528,7 +4529,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4549,7 +4550,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -4567,7 +4568,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "hex",
@@ -4580,7 +4581,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -4593,7 +4594,7 @@ dependencies = [
 [[package]]
 name = "move-proc-macros"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "quote",
  "syn 2.0.106",
@@ -4602,7 +4603,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives"
 version = "0.1.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -4617,7 +4618,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "once_cell",
  "phf",
@@ -4627,7 +4628,7 @@ dependencies = [
 [[package]]
 name = "move-trace-format"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -4638,7 +4639,7 @@ dependencies = [
 [[package]]
 name = "move-vm-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "move-binary-format",
  "once_cell",
@@ -4647,7 +4648,7 @@ dependencies = [
 [[package]]
 name = "move-vm-profiler"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "move-vm-config",
  "once_cell",
@@ -4657,7 +4658,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "better_any",
  "fail",
@@ -4677,7 +4678,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -4691,7 +4692,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -5134,6 +5135,28 @@ checksum = "e9567693dd2f9a4339cb0a54adfcc0cb431c0ac88b2e46c6ddfb5f5d11a1cc4f"
 dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "packed_struct"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36b29691432cc9eff8b282278473b63df73bea49bc3ec5e67f31a3ae9c3ec190"
+dependencies = [
+ "bitvec 1.0.1",
+ "packed_struct_codegen",
+ "serde",
+]
+
+[[package]]
+name = "packed_struct_codegen"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cd6706dfe50d53e0f6aa09e12c034c44faacd23e966ae5a209e8bdb8f179f98"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -5698,8 +5721,8 @@ dependencies = [
 
 [[package]]
 name = "product_common"
-version = "0.8.2"
-source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.2#9e569ed450559d778c2f75c4e9698effb590449d"
+version = "0.8.3"
+source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.3#259fe697d1246f2f589b97c976f1bc3ee79fae88"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5707,7 +5730,7 @@ dependencies = [
  "cfg-if",
  "fastcrypto",
  "iota-keys",
- "iota-sdk 1.6.1",
+ "iota-sdk 1.7.0",
  "iota_interaction",
  "iota_interaction_rust",
  "iota_interaction_ts",
@@ -5742,8 +5765,8 @@ dependencies = [
 
 [[package]]
 name = "prometheus-closure-metric"
-version = "1.6.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -6864,8 +6887,8 @@ dependencies = [
 
 [[package]]
 name = "shared-crypto"
-version = "1.6.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "bcs",
  "eyre",
@@ -7081,7 +7104,7 @@ dependencies = [
 [[package]]
 name = "starfish-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "fastcrypto",
  "iota-network-stack",
@@ -7857,8 +7880,8 @@ dependencies = [
 
 [[package]]
 name = "typed-store-error"
-version = "1.6.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.6.1#7a7a3e40745d7a8ae54afae65f64301f4743e70b"
+version = "1.7.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.7.0#5de884a0608171bb5b4fc153c97830b2796e19e6"
 dependencies = [
  "serde",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,11 @@ anyhow = "1.0"
 async-trait = "0.1"
 bcs = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", tag = "v1.6.1", package = "iota-sdk" }
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", default-features = false, tag = "v0.8.2", package = "iota_interaction" }
-iota_interaction_rust = { git = "https://github.com/iotaledger/product-core.git", default-features = false, tag = "v0.8.2", package = "iota_interaction_rust" }
-iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", default-features = false, tag = "v0.8.2", package = "iota_interaction_ts" }
-product_common = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.2", default-features = false, package = "product_common" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", tag = "v1.7.0", package = "iota-sdk" }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", default-features = false, tag = "v0.8.3", package = "iota_interaction" }
+iota_interaction_rust = { git = "https://github.com/iotaledger/product-core.git", default-features = false, tag = "v0.8.3", package = "iota_interaction_rust" }
+iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", default-features = false, tag = "v0.8.3", package = "iota_interaction_ts" }
+product_common = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.3", default-features = false, package = "product_common" }
 secret-storage = { git = "https://github.com/iotaledger/secret-storage", tag = "v0.3.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/bindings/wasm/hierarchies_wasm/Cargo.toml
+++ b/bindings/wasm/hierarchies_wasm/Cargo.toml
@@ -18,8 +18,8 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 anyhow = "1.0"
 console_error_panic_hook = "0.1"
-iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.2", package = "iota_interaction", default-features = false }
-iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.2", package = "iota_interaction_ts" }
+iota_interaction = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.3", package = "iota_interaction", default-features = false }
+iota_interaction_ts = { git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.3", package = "iota_interaction_ts" }
 js-sys = { version = "0.3" }
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6"
@@ -28,7 +28,7 @@ wasm-bindgen-futures = { version = "0.4", default-features = false }
 
 [dependencies.product_common]
 git = "https://github.com/iotaledger/product-core.git"
-tag = "v0.8.2"
+tag = "v0.8.3"
 package = "product_common"
 features = [
   "core-client",


### PR DESCRIPTION
# Description of change

- pin all iota.git dependencies to `tag = "v1.7.0"`
- pin all product-core.git dependencies to `tag = "v0.8.3"`
- hierarchies_wasm: @iota/iota-interaction-ts dependency stays with "^0.8.0"
