### PR TITLE
feat: bump up the iota to `1.13.1` and product common to `0.8.8`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,6 +257,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "ark-bn254"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,9 +499,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.34"
+version = "0.4.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e86f6d3dc9dc4352edeea6b8e499e13e3f5dc3b964d7ca5fd411415a3498473"
+checksum = "98ec5f6c2f8bc326c994cb9e241cc257ddaba9afa8555a43cffbb5dd86efaa37"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -599,6 +605,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-server"
+version = "0.6.1"
+source = "git+https://github.com/bmwill/axum-server.git?rev=f44323e271afdd1365fd0c8b0a4c0bbdf4956cb7#f44323e271afdd1365fd0c8b0a4c0bbdf4956cb7"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower 0.4.13",
+ "tower-service",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -655,9 +684,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+checksum = "0e050f626429857a27ddccb31e0aca21356bfa709c04041aefddac081a8f068a"
 
 [[package]]
 name = "bcs"
@@ -915,9 +944,9 @@ dependencies = [
 
 [[package]]
 name = "bnum"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e31ea183f6ee62ac8b8a8cf7feddd766317adfb13ff469de57ce033efd6a790"
+checksum = "f781dba93de3a5ef6dc5b17c9958b208f6f3f021623b360fb605ea51ce443f10"
 
 [[package]]
 name = "brotli"
@@ -958,9 +987,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "byte-slice-cast"
@@ -1006,9 +1035,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.48"
+version = "1.2.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c481bdbf0ed3b892f6f806287d72acd515b352a4ec27a208489b8c1bc839633a"
+checksum = "90583009037521a116abf44494efecd645ba48b6622457080f080b85544e2215"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1200,9 +1229,9 @@ dependencies = [
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.33"
+version = "0.4.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302266479cb963552d11bd042013a58ef1adc56768016c8b82b4199488f2d4ad"
+checksum = "b0f7ac3e5b97fdce45e8922fb05cae2c37f7bbd63d30dd94821dacfd8f3f2bf2"
 dependencies = [
  "brotli",
  "compression-core",
@@ -1221,13 +1250,13 @@ checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 [[package]]
 name = "consensus-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "fastcrypto",
  "iota-network-stack",
+ "iota-sdk-types",
  "rand 0.8.5",
  "serde",
- "shared-crypto",
 ]
 
 [[package]]
@@ -1902,7 +1931,7 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 [[package]]
 name = "enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "serde_yaml",
 ]
@@ -2631,6 +2660,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bcs",
+ "hyper",
  "iota_interaction",
  "iota_interaction_rust",
  "iota_interaction_ts",
@@ -2650,7 +2680,8 @@ dependencies = [
  "anyhow",
  "chrono",
  "hierarchies",
- "iota-sdk 1.12.0",
+ "hyper",
+ "iota-sdk 1.13.1",
  "product_common",
  "tokio",
 ]
@@ -2738,9 +2769,9 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2793,9 +2824,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.18"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e9a2a24dc5c6821e71a7030e1e14b7b632acac55c40e9d2e082c621261bb56"
+checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2887,9 +2918,9 @@ checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -2901,9 +2932,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
 
 [[package]]
 name = "icu_provider"
@@ -3077,7 +3108,7 @@ dependencies = [
 [[package]]
 name = "iota-adapter-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3103,9 +3134,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "iota-common"
+version = "1.13.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
+dependencies = [
+ "anyhow",
+ "fastcrypto",
+ "futures",
+ "iota-metrics",
+ "iota-tls",
+ "iota-types",
+ "parking_lot 0.12.5",
+ "prometheus",
+ "rand 0.8.5",
+ "reqwest",
+ "snap",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "iota-config"
-version = "1.12.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+version = "1.13.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "anemo",
  "anyhow",
@@ -3169,8 +3220,8 @@ dependencies = [
 
 [[package]]
 name = "iota-enum-compat-util"
-version = "1.12.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+version = "1.13.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "serde_yaml",
 ]
@@ -3178,7 +3229,7 @@ dependencies = [
 [[package]]
 name = "iota-execution"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "iota-adapter-latest",
  "iota-move-natives-latest",
@@ -3195,8 +3246,8 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-common"
-version = "1.12.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+version = "1.13.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "iota-execution",
  "iota-protocol-config",
@@ -3206,8 +3257,8 @@ dependencies = [
 
 [[package]]
 name = "iota-http"
-version = "1.12.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+version = "1.13.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "bytes",
  "http",
@@ -3226,8 +3277,8 @@ dependencies = [
 
 [[package]]
 name = "iota-json"
-version = "1.12.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+version = "1.13.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3243,8 +3294,8 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-api"
-version = "1.12.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+version = "1.13.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -3263,8 +3314,8 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-types"
-version = "1.12.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+version = "1.13.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3298,19 +3349,19 @@ dependencies = [
 
 [[package]]
 name = "iota-keys"
-version = "1.12.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+version = "1.13.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "anyhow",
  "bip32",
  "fastcrypto",
+ "iota-sdk-types",
  "iota-types",
  "rand 0.8.5",
  "regex",
  "serde",
  "serde_json",
  "serde_with",
- "shared-crypto",
  "signature 1.6.4",
  "slip10_ed25519",
  "tiny-bip39",
@@ -3319,8 +3370,8 @@ dependencies = [
 
 [[package]]
 name = "iota-macros"
-version = "1.12.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+version = "1.13.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "futures",
  "iota-proc-macros",
@@ -3330,8 +3381,8 @@ dependencies = [
 
 [[package]]
 name = "iota-metrics"
-version = "1.12.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+version = "1.13.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -3357,7 +3408,7 @@ dependencies = [
 [[package]]
 name = "iota-move-natives-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "bcs",
  "better_any",
@@ -3379,8 +3430,8 @@ dependencies = [
 
 [[package]]
 name = "iota-names"
-version = "1.12.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+version = "1.13.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3392,8 +3443,8 @@ dependencies = [
 
 [[package]]
 name = "iota-network-stack"
-version = "1.12.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+version = "1.13.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "anemo",
  "bcs",
@@ -3422,8 +3473,8 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc"
-version = "1.12.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+version = "1.13.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -3433,8 +3484,8 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc-macros"
-version = "1.12.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+version = "1.13.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -3446,8 +3497,8 @@ dependencies = [
 
 [[package]]
 name = "iota-package-resolver"
-version = "1.12.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+version = "1.13.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "async-trait",
  "bcs",
@@ -3462,8 +3513,8 @@ dependencies = [
 
 [[package]]
 name = "iota-proc-macros"
-version = "1.12.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+version = "1.13.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "msim-macros",
  "proc-macro2",
@@ -3473,8 +3524,8 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config"
-version = "1.12.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+version = "1.13.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "clap",
  "iota-protocol-config-macros",
@@ -3488,8 +3539,8 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config-macros"
-version = "1.12.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+version = "1.13.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3498,8 +3549,8 @@ dependencies = [
 
 [[package]]
 name = "iota-rest-api"
-version = "1.12.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+version = "1.13.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "anyhow",
  "axum",
@@ -3507,7 +3558,7 @@ dependencies = [
  "fastcrypto",
  "iota-network-stack",
  "iota-protocol-config",
- "iota-rust-sdk",
+ "iota-sdk-types",
  "iota-types",
  "itertools 0.13.0",
  "mime",
@@ -3523,26 +3574,6 @@ dependencies = [
  "tap",
  "tokio",
  "url",
-]
-
-[[package]]
-name = "iota-rust-sdk"
-version = "0.0.0"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=d7084eaf0564f4e2381b2e8408ee1f7d51468450#d7084eaf0564f4e2381b2e8408ee1f7d51468450"
-dependencies = [
- "base64ct",
- "bcs",
- "blake2",
- "bnum",
- "bs58 0.5.1",
- "hex",
- "roaring",
- "schemars 0.8.22",
- "serde",
- "serde_derive",
- "serde_json",
- "serde_with",
- "winnow 0.6.26",
 ]
 
 [[package]]
@@ -3579,8 +3610,8 @@ dependencies = [
 
 [[package]]
 name = "iota-sdk"
-version = "1.12.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+version = "1.13.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3591,11 +3622,13 @@ dependencies = [
  "futures",
  "futures-core",
  "getset",
+ "iota-common",
  "iota-config",
  "iota-json",
  "iota-json-rpc-api",
  "iota-json-rpc-types",
  "iota-keys",
+ "iota-sdk-types",
  "iota-transaction-builder",
  "iota-types",
  "jsonrpsee",
@@ -3605,16 +3638,62 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "shared-crypto",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
 ]
 
 [[package]]
+name = "iota-sdk-types"
+version = "0.0.1-alpha.1"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=05608b7e4a5b96d85f84e1970a517f6f174beb8b#05608b7e4a5b96d85f84e1970a517f6f174beb8b"
+dependencies = [
+ "base64ct",
+ "bcs",
+ "blake2",
+ "bnum",
+ "bs58 0.5.1",
+ "eyre",
+ "hex",
+ "itertools 0.13.0",
+ "paste",
+ "roaring",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "serde_with",
+ "strum 0.27.2",
+ "thiserror 2.0.17",
+ "winnow 0.7.14",
+]
+
+[[package]]
+name = "iota-tls"
+version = "1.13.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
+dependencies = [
+ "anyhow",
+ "arc-swap",
+ "axum",
+ "axum-server",
+ "ed25519",
+ "fastcrypto",
+ "pkcs8 0.10.2",
+ "rcgen",
+ "reqwest",
+ "rustls",
+ "rustls-webpki",
+ "tokio",
+ "tokio-rustls",
+ "tower-layer",
+ "x509-parser",
+]
+
+[[package]]
 name = "iota-transaction-builder"
-version = "1.12.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+version = "1.13.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3630,8 +3709,8 @@ dependencies = [
 
 [[package]]
 name = "iota-types"
-version = "1.12.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+version = "1.13.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "anemo",
  "anyhow",
@@ -3655,8 +3734,8 @@ dependencies = [
  "iota-macros",
  "iota-network-stack",
  "iota-protocol-config",
- "iota-rust-sdk",
  "iota-sdk 1.1.5",
+ "iota-sdk-types",
  "itertools 0.13.0",
  "lru",
  "move-binary-format",
@@ -3680,7 +3759,6 @@ dependencies = [
  "serde-name",
  "serde_json",
  "serde_with",
- "shared-crypto",
  "signature 1.6.4",
  "starfish-config",
  "static_assertions",
@@ -3696,7 +3774,7 @@ dependencies = [
 [[package]]
 name = "iota-verifier-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "iota-types",
  "move-abstract-interpreter",
@@ -3710,8 +3788,8 @@ dependencies = [
 
 [[package]]
 name = "iota_interaction"
-version = "0.8.7"
-source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.7#86e1276c2f03dd7ff9d0de63f0f60c651c000906"
+version = "0.8.8"
+source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.8#8356931932d1d62e7ac440a4c1b1f4d1b67b75c9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3723,8 +3801,10 @@ dependencies = [
  "fastcrypto",
  "fastcrypto-zkp",
  "hex",
+ "hyper",
  "indexmap 2.12.1",
- "iota-sdk 1.12.0",
+ "iota-sdk 1.13.1",
+ "iota-sdk-types",
  "itertools 0.13.0",
  "jsonpath-rust",
  "jsonrpsee",
@@ -3740,7 +3820,6 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "serde_with",
- "shared-crypto",
  "strum 0.25.0",
  "thiserror 1.0.69",
  "tokio",
@@ -3750,8 +3829,8 @@ dependencies = [
 
 [[package]]
 name = "iota_interaction_rust"
-version = "0.8.7"
-source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.7#86e1276c2f03dd7ff9d0de63f0f60c651c000906"
+version = "0.8.8"
+source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.8#8356931932d1d62e7ac440a4c1b1f4d1b67b75c9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3763,8 +3842,8 @@ dependencies = [
 
 [[package]]
 name = "iota_interaction_ts"
-version = "0.8.7"
-source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.7#86e1276c2f03dd7ff9d0de63f0f60c651c000906"
+version = "0.8.8"
+source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.8#8356931932d1d62e7ac440a4c1b1f4d1b67b75c9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3775,6 +3854,7 @@ dependencies = [
  "futures",
  "getrandom 0.2.16",
  "getrandom 0.3.4",
+ "hyper",
  "iota-sdk 1.1.5",
  "iota_interaction",
  "js-sys",
@@ -4160,9 +4240,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
 name = "libflate"
@@ -4196,20 +4276,20 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
+checksum = "df15f6eac291ed1cf25865b1ee60399f57e7c227e7f51bdbd4c5270396a9ed50"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall 0.6.0",
 ]
 
 [[package]]
 name = "libsodium-sys-stable"
-version = "1.22.5"
+version = "1.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8119f38969584f49be1d1da6f011ed268cc64e3eac5b4f9374c40d9694ad1421"
+checksum = "186bf786351b393a91025e9fc2f1058b8b8e1c7ecfde142ed829c209ab95daff"
 dependencies = [
  "cc",
  "libc",
@@ -4224,9 +4304,9 @@ dependencies = [
 
 [[package]]
 name = "libz-rs-sys"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "840db8cf39d9ec4dd794376f38acc40d0fc65eec2a8f484f7fd375b84602becd"
+checksum = "15413ef615ad868d4d65dce091cb233b229419c7c0c4bcaa746c0901c49ff39c"
 dependencies = [
  "zlib-rs",
 ]
@@ -4260,11 +4340,11 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -4383,9 +4463,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
@@ -4395,7 +4475,7 @@ dependencies = [
 [[package]]
 name = "move-abstract-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "move-binary-format",
  "move-bytecode-verifier-meter",
@@ -4404,12 +4484,12 @@ dependencies = [
 [[package]]
 name = "move-abstract-stack"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "anyhow",
  "enum-compat-util",
@@ -4424,12 +4504,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4445,7 +4525,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "anyhow",
  "indexmap 2.12.1",
@@ -4459,7 +4539,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -4474,7 +4554,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-meter"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -4484,7 +4564,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4504,7 +4584,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4539,7 +4619,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4563,7 +4643,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4584,7 +4664,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4605,7 +4685,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -4623,7 +4703,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "anyhow",
  "hex",
@@ -4636,7 +4716,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -4649,7 +4729,7 @@ dependencies = [
 [[package]]
 name = "move-proc-macros"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "quote",
  "syn 2.0.111",
@@ -4658,7 +4738,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives"
 version = "0.1.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -4673,7 +4753,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "once_cell",
  "phf",
@@ -4683,7 +4763,7 @@ dependencies = [
 [[package]]
 name = "move-trace-format"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -4694,7 +4774,7 @@ dependencies = [
 [[package]]
 name = "move-vm-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "move-binary-format",
  "once_cell",
@@ -4703,7 +4783,7 @@ dependencies = [
 [[package]]
 name = "move-vm-profiler"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "move-vm-config",
  "once_cell",
@@ -4713,7 +4793,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "better_any",
  "fail",
@@ -4733,7 +4813,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -4747,7 +4827,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -5724,7 +5804,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit 0.23.7",
+ "toml_edit 0.23.10+spec-1.0.0",
 ]
 
 [[package]]
@@ -5784,16 +5864,18 @@ dependencies = [
 
 [[package]]
 name = "product_common"
-version = "0.8.7"
-source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.7#86e1276c2f03dd7ff9d0de63f0f60c651c000906"
+version = "0.8.8"
+source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.8#8356931932d1d62e7ac440a4c1b1f4d1b67b75c9"
 dependencies = [
  "anyhow",
  "async-trait",
  "bcs",
  "cfg-if",
  "fastcrypto",
+ "hyper",
  "iota-keys",
- "iota-sdk 1.12.0",
+ "iota-sdk 1.13.1",
+ "iota-sdk-types",
  "iota_interaction",
  "iota_interaction_rust",
  "iota_interaction_ts",
@@ -5828,8 +5910,8 @@ dependencies = [
 
 [[package]]
 name = "prometheus-closure-metric"
-version = "1.12.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+version = "1.13.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -5837,9 +5919,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.2"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "101fec8d036f8d9d4a1e8ebf90d566d1d798f3b1aa379d2576a54a0d9acea5bd"
+checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -5847,9 +5929,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.14.2"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2d93e596a829ebe00afa41c3a056e6308d6b8a4c7d869edf184e2c91b1ba564"
+checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
@@ -6186,6 +6268,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec96166dafa0886eb81fe1c0a388bece180fbef2135f97c1e2cf8302e74b43b5"
+dependencies = [
+ "bitflags 2.10.0",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6247,9 +6338,9 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
-version = "0.12.24"
+version = "0.12.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
+checksum = "3b4c14b2d9afca6a60277086b0cc6a6ae0b568f6f7916c943a8cdc79f8be240f"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -6279,7 +6370,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "tower 0.5.2",
- "tower-http 0.6.7",
+ "tower-http 0.6.8",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -6330,9 +6421,9 @@ checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
 name = "roaring"
-version = "0.10.12"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e8d2cfa184d94d0726d650a9f4a1be7f9b76ac9fdb954219878dc00c1c1e7b"
+checksum = "8ba9ce64a8f45d7fc86358410bb1a82e8c987504c0d4900e9141d69a9f26c885"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -6479,9 +6570,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "708c0f9d5f54ba0272468c1d306a52c495b31fa155e91bc25371e6df7996908c"
+checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
 dependencies = [
  "web-time",
  "zeroize",
@@ -6971,18 +7062,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shared-crypto"
-version = "1.12.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
-dependencies = [
- "bcs",
- "eyre",
- "fastcrypto",
- "serde",
- "serde_repr",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7015,9 +7094,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "similar"
@@ -7189,15 +7268,15 @@ dependencies = [
 [[package]]
 name = "starfish-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "blake3",
  "fastcrypto",
  "iota-network-stack",
+ "iota-sdk-types",
  "rand 0.8.5",
  "rs_merkle",
  "serde",
- "shared-crypto",
 ]
 
 [[package]]
@@ -7725,9 +7804,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.3"
+version = "0.7.4+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
+checksum = "fe3cea6b2aa3b910092f6abd4053ea464fab5f9c170ba5e9a6aead16ec4af2b6"
 dependencies = [
  "serde_core",
 ]
@@ -7759,21 +7838,21 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.23.7"
+version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap 2.12.1",
- "toml_datetime 0.7.3",
+ "toml_datetime 0.7.4+spec-1.0.0",
  "toml_parser",
  "winnow 0.7.14",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.4"
+version = "1.0.5+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
+checksum = "4c03bee5ce3696f31250db0bbaff18bc43301ce0e8db2ed1f07cbb2acf89984c"
 dependencies = [
  "winnow 0.7.14",
 ]
@@ -7911,9 +7990,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf146f99d442e8e68e585f5d798ccd3cad9a7835b917e09728880a862706456"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags 2.10.0",
  "bytes",
@@ -8007,8 +8086,8 @@ dependencies = [
 
 [[package]]
 name = "typed-store-error"
-version = "1.12.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.12.0#37d015710eafbcf46e2e0901075ddfe9dbdcc284"
+version = "1.13.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.13.1#7c77b7d8f998d1ac265586763b090c30abddb7e6"
 dependencies = [
  "serde",
  "thiserror 1.0.69",
@@ -8034,9 +8113,9 @@ dependencies = [
 
 [[package]]
 name = "typeshare-annotation"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a615d6c2764852a2e88a4f16e9ce1ea49bb776b5872956309e170d63a042a34f"
+checksum = "621963e302416b389a1ec177397e9e62de849a78bd8205d428608553def75350"
 dependencies = [
  "quote",
  "syn 2.0.111",
@@ -8178,9 +8257,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.18.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
  "getrandom 0.3.4",
  "js-sys",
@@ -8881,15 +8960,6 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
@@ -9114,9 +9184,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f06ae92f42f5e5c42443fd094f245eb656abf56dd7cce9b8b263236565e00f2"
+checksum = "51f936044d677be1a1168fae1d03b583a285a5dd9d8cbf7b24c23aa1fc775235"
 
 [[package]]
 name = "zopfli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,13 @@ anyhow = "1.0"
 async-trait = "0.1"
 bcs = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
-iota-sdk = { package = "iota-sdk", git = "https://github.com/iotaledger/iota.git", tag = "v1.12.0" }
-iota_interaction = { package = "iota_interaction", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.7", default-features = false }
-iota_interaction_rust = { package = "iota_interaction_rust", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.7", default-features = false }
-iota_interaction_ts = { package = "iota_interaction_ts", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.7", default-features = false }
-product_common = { package = "product_common", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.7", default-features = false }
+# Latest hyper is not compatible with axum-server used by iota-sdk. We need to pin it to 1.7 until iota-sdk upgrades axum-server.
+hyper = "=1.7" # Fix for iota-sdk 1.13 issue with axum-server.
+iota-sdk = { package = "iota-sdk", git = "https://github.com/iotaledger/iota.git", tag = "v1.13.1" }
+iota_interaction = { package = "iota_interaction", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.8", default-features = false }
+iota_interaction_rust = { package = "iota_interaction_rust", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.8", default-features = false }
+iota_interaction_ts = { package = "iota_interaction_ts", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.8", default-features = false }
+product_common = { package = "product_common", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.8", default-features = false }
 secret-storage = { git = "https://github.com/iotaledger/secret-storage", tag = "v0.3.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/bindings/wasm/hierarchies_wasm/Cargo.toml
+++ b/bindings/wasm/hierarchies_wasm/Cargo.toml
@@ -18,8 +18,10 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 anyhow = "1.0"
 console_error_panic_hook = "0.1"
-iota_interaction = { package = "iota_interaction", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.7", default-features = false }
-iota_interaction_ts = { package = "iota_interaction_ts", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.7" }
+# Latest hyper is not compatible with axum-server used by iota-sdk. We need to pin it to 1.7 until iota-sdk upgrades axum-server.
+hyper = "=1.7" # Fix for iota-sdk 1.13 issue with axum-server.
+iota_interaction = { package = "iota_interaction", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.8", default-features = false }
+iota_interaction_ts = { package = "iota_interaction_ts", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.8" }
 js-sys = { version = "0.3" }
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6"
@@ -34,7 +36,7 @@ features = ["default-http-client", "gas-station"]
 [dependencies.product_common]
 package = "product_common"
 git = "https://github.com/iotaledger/product-core.git"
-tag = "v0.8.7"
+tag = "v0.8.8"
 features = [
   "default-http-client",
   "binding-utils",

--- a/bindings/wasm/hierarchies_wasm/package-lock.json
+++ b/bindings/wasm/hierarchies_wasm/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.1.4",
             "license": "Apache-2.0",
             "dependencies": {
-                "@iota/iota-interaction-ts": "^0.9.0"
+                "@iota/iota-interaction-ts": "^0.10.0"
             },
             "devDependencies": {
                 "@types/lodash": "^4.17.20",
@@ -37,7 +37,7 @@
                 "node": ">=20"
             },
             "peerDependencies": {
-                "@iota/iota-sdk": "^1.7.1"
+                "@iota/iota-sdk": "^1.9.1"
             }
         },
         "node_modules/@0no-co/graphql.web": {
@@ -267,34 +267,33 @@
             }
         },
         "node_modules/@iota/bcs": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@iota/bcs/-/bcs-1.3.0.tgz",
-            "integrity": "sha512-R99rbggmRuRIhfPpmmceo87gRrVrfM1oZRhGhK5dmbOk5wooo3rMYzN/a0KzQ9Ieig/FisuV5uDEkFheQXr7WA==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@iota/bcs/-/bcs-1.4.0.tgz",
+            "integrity": "sha512-Bpg8uPB3UTweJyFS3G+aycGcTCxaJQi2a9bEy2QXWMBM8a/tLN1KCg4IzKWkAJ4FyMNrZZrdXiBqAzmNK6xdVQ==",
             "peer": true,
             "dependencies": {
                 "bs58": "^6.0.0"
             }
         },
         "node_modules/@iota/iota-interaction-ts": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/@iota/iota-interaction-ts/-/iota-interaction-ts-0.9.0.tgz",
-            "integrity": "sha512-spOc7baucxhBGaRQi32kPGdIj8g65tHzYBG5klh+DnHz4PGQl3tkjVgimfAB4M1wIhkQU/RfURTh4ygsVggMFg==",
-            "license": "Apache-2.0",
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/@iota/iota-interaction-ts/-/iota-interaction-ts-0.10.0.tgz",
+            "integrity": "sha512-oOSVb+EAOZ+gqBylVf2tj9kYNvir/E3Q9cbMCozaE1yFyk0jFOgfkCoUUgSJgeQJlwwu1jBM8RqTOLlKOchKVw==",
             "engines": {
                 "node": ">=20"
             },
             "peerDependencies": {
-                "@iota/iota-sdk": "^1.7.1"
+                "@iota/iota-sdk": "^1.9.1"
             }
         },
         "node_modules/@iota/iota-sdk": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/@iota/iota-sdk/-/iota-sdk-1.7.1.tgz",
-            "integrity": "sha512-ZUGPGldQPI2j9twUkylRuE/JkP9U4T7eOFdid4G8UufCs5VdepTISv76IoTSgn/K27xQhVjULsqx4rhlUWSXeA==",
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/@iota/iota-sdk/-/iota-sdk-1.9.1.tgz",
+            "integrity": "sha512-tsJJ6fJHPHTYxXX0BlRYjerKhaSH0XhBNkVGQRCCOSnunJGsB5ivG3ijQHygyA0yV+QOQ237bkhijmHAKZWGkw==",
             "peer": true,
             "dependencies": {
                 "@graphql-typed-document-node/core": "^3.2.0",
-                "@iota/bcs": "1.3.0",
+                "@iota/bcs": "1.4.0",
                 "@noble/curves": "^1.4.2",
                 "@noble/hashes": "^1.4.0",
                 "@scure/bip32": "^1.4.0",
@@ -305,7 +304,7 @@
                 "gql.tada": "^1.8.2",
                 "graphql": "^16.9.0",
                 "tweetnacl": "^1.0.3",
-                "valibot": "^0.36.0"
+                "valibot": "^1.2.0"
             },
             "engines": {
                 "node": ">=20"
@@ -7287,11 +7286,18 @@
             "license": "MIT"
         },
         "node_modules/valibot": {
-            "version": "0.36.0",
-            "resolved": "https://registry.npmjs.org/valibot/-/valibot-0.36.0.tgz",
-            "integrity": "sha512-CjF1XN4sUce8sBK9TixrDqFM7RwNkuXdJu174/AwmQUB62QbCQADg5lLe8ldBalFgtj1uKj+pKwDJiNo4Mn+eQ==",
-            "license": "MIT",
-            "peer": true
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.2.0.tgz",
+            "integrity": "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==",
+            "peer": true,
+            "peerDependencies": {
+                "typescript": ">=5"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/verror": {
             "version": "1.10.0",

--- a/bindings/wasm/hierarchies_wasm/package.json
+++ b/bindings/wasm/hierarchies_wasm/package.json
@@ -74,10 +74,10 @@
         "wasm-opt": "^1.4.0"
     },
     "dependencies": {
-        "@iota/iota-interaction-ts": "^0.9.0"
+        "@iota/iota-interaction-ts": "^0.10.0"
     },
     "peerDependencies": {
-        "@iota/iota-sdk": "^1.7.1"
+        "@iota/iota-sdk": "^1.9.1"
     },
     "engines": {
         "node": ">=20"

--- a/hierarchies-rs/examples/Cargo.toml
+++ b/hierarchies-rs/examples/Cargo.toml
@@ -8,6 +8,7 @@ edition.workspace = true
 anyhow.workspace = true
 chrono.workspace = true
 hierarchies = { path = "../hierarchies" }
+hyper = { workspace = true } # Fix for iota-sdk 1.13 issue with axum-server.
 iota-sdk = { workspace = true }
 product_common = { workspace = true, features = ["test-utils"] }
 tokio.workspace = true

--- a/hierarchies-rs/hierarchies/Cargo.toml
+++ b/hierarchies-rs/hierarchies/Cargo.toml
@@ -26,6 +26,7 @@ product_common = { workspace = true, features = ["move-history-manager"] }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 iota_interaction = { workspace = true, default-features = false }
 iota_interaction_rust = { workspace = true, default-features = false }
+hyper = { workspace = true } # Fix for iota-sdk 1.13 issue with axum-server.
 secret-storage = { workspace = true, default-features = false }
 tokio = { workspace = true }
 


### PR DESCRIPTION
# Description of change

The following dependencies have been changed:
- [ ] tokio version update to: -
- [ ] fastcrypto version update to rev = "-"
- [x] hierarchies_wasm: new peerDep. version for `@iota/iota-sdk: 1.9.1`
- [x] hierarchies_wasm: pin @iota/iota-interaction-ts dependency to "^0.10.0"
- [x] pin all product-core.git dependencies to `tag="v0.8.8"`
- [x] pin all iota.git dependencies to `tag = "v1.13.1`
- [x] pin `hyper` to `v1.7`

## Links to any relevant issues
https://github.com/iotaledger/product-core/issues/67