### PR TITLE
release: rust: v0.1.8 npm: v0.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2655,7 +2655,7 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hierarchies"
-version = "0.1.7-alpha"
+version = "0.1.8-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2675,7 +2675,7 @@ dependencies = [
 
 [[package]]
 name = "hierarchies_examples"
-version = "0.1.7-alpha"
+version = "0.1.8-alpha"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["hierarchies-rs/examples", "hierarchies-rs/hierarchies"]
 exclude = ["bindings/wasm/hierarchies_wasm"]
 
 [workspace.package]
-version = "0.1.7-alpha"
+version = "0.1.8-alpha"
 authors = ["IOTA Stiftung"]
 edition = "2024"
 homepage = "https://www.iota.org"

--- a/bindings/wasm/hierarchies_wasm/Cargo.toml
+++ b/bindings/wasm/hierarchies_wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hierarchies_wasm"
-version = "0.1.7-alpha"
+version = "0.1.8-alpha"
 authors = ["IOTA Stiftung"]
 edition = "2024"
 homepage = "https://www.iota.org"

--- a/bindings/wasm/hierarchies_wasm/package-lock.json
+++ b/bindings/wasm/hierarchies_wasm/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@iota/hierarchies",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@iota/hierarchies",
-            "version": "0.1.4",
+            "version": "0.1.5",
             "license": "Apache-2.0",
             "dependencies": {
                 "@iota/iota-interaction-ts": "^0.10.0"

--- a/bindings/wasm/hierarchies_wasm/package.json
+++ b/bindings/wasm/hierarchies_wasm/package.json
@@ -3,7 +3,7 @@
     "author": "IOTA Foundation <info@iota.org>",
     "description": "WASM bindings for IOTA Hierarchies - To be used in JavaScript/TypeScript",
     "homepage": "https://www.iota.org",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "license": "Apache-2.0",
     "repository": {
         "type": "git",


### PR DESCRIPTION
# Description of change

* Bump npmjs version for wasm_hierarchies to `0.1.5`
* Bump cargo versions to `0.1.8`