### PR TITLE
bump up the iota to 1.19.1 and product core to 0.8.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1174,13 +1174,14 @@ dependencies = [
 [[package]]
 name = "consensus-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "fastcrypto",
  "iota-network-stack",
  "iota-sdk-types",
  "rand 0.8.5",
  "serde",
+ "tracing",
 ]
 
 [[package]]
@@ -1849,7 +1850,7 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 [[package]]
 name = "enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "serde_yaml",
 ]
@@ -2608,7 +2609,7 @@ dependencies = [
  "chrono",
  "hierarchies",
  "hyper",
- "iota-sdk 1.18.1",
+ "iota-sdk 1.19.1",
  "product_common",
  "tokio",
 ]
@@ -3028,7 +3029,7 @@ dependencies = [
 [[package]]
 name = "iota-adapter-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3055,27 +3056,30 @@ dependencies = [
 
 [[package]]
 name = "iota-common"
-version = "1.18.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+version = "1.19.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "anyhow",
  "fastcrypto",
  "futures",
+ "iota-macros",
  "iota-metrics",
  "iota-types",
+ "once_cell",
  "parking_lot 0.12.5",
  "prometheus",
  "rand 0.8.5",
  "reqwest 0.12.26",
  "snap",
+ "tempfile",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "iota-config"
-version = "1.18.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+version = "1.19.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "anemo",
  "anyhow",
@@ -3139,8 +3143,8 @@ dependencies = [
 
 [[package]]
 name = "iota-enum-compat-util"
-version = "1.18.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+version = "1.19.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "serde_yaml",
 ]
@@ -3148,7 +3152,7 @@ dependencies = [
 [[package]]
 name = "iota-execution"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "iota-adapter-latest",
  "iota-move-natives-latest",
@@ -3165,8 +3169,8 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-common"
-version = "1.18.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+version = "1.19.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "iota-execution",
  "iota-protocol-config",
@@ -3176,8 +3180,8 @@ dependencies = [
 
 [[package]]
 name = "iota-http"
-version = "1.18.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+version = "1.19.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "bytes",
  "http",
@@ -3196,8 +3200,8 @@ dependencies = [
 
 [[package]]
 name = "iota-json"
-version = "1.18.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+version = "1.19.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3213,8 +3217,8 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-api"
-version = "1.18.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+version = "1.19.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -3233,8 +3237,8 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-types"
-version = "1.18.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+version = "1.19.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3261,15 +3265,15 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "strum 0.26.3",
+ "strum 0.27.2",
  "tabled",
  "tracing",
 ]
 
 [[package]]
 name = "iota-keys"
-version = "1.18.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+version = "1.19.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "anyhow",
  "bip32",
@@ -3289,8 +3293,8 @@ dependencies = [
 
 [[package]]
 name = "iota-macros"
-version = "1.18.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+version = "1.19.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "futures",
  "iota-proc-macros",
@@ -3300,8 +3304,8 @@ dependencies = [
 
 [[package]]
 name = "iota-metrics"
-version = "1.18.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+version = "1.19.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -3327,7 +3331,7 @@ dependencies = [
 [[package]]
 name = "iota-move-natives-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "bcs",
  "better_any",
@@ -3350,8 +3354,8 @@ dependencies = [
 
 [[package]]
 name = "iota-names"
-version = "1.18.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+version = "1.19.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3363,8 +3367,8 @@ dependencies = [
 
 [[package]]
 name = "iota-network-stack"
-version = "1.18.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+version = "1.19.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "anemo",
  "bcs",
@@ -3393,8 +3397,8 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc"
-version = "1.18.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+version = "1.19.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -3404,8 +3408,8 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc-macros"
-version = "1.18.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+version = "1.19.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -3417,8 +3421,8 @@ dependencies = [
 
 [[package]]
 name = "iota-package-resolver"
-version = "1.18.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+version = "1.19.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "async-trait",
  "bcs",
@@ -3433,8 +3437,8 @@ dependencies = [
 
 [[package]]
 name = "iota-proc-macros"
-version = "1.18.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+version = "1.19.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "msim-macros",
  "proc-macro2",
@@ -3444,8 +3448,8 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config"
-version = "1.18.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+version = "1.19.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "clap",
  "iota-protocol-config-macros",
@@ -3459,8 +3463,8 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config-macros"
-version = "1.18.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+version = "1.19.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3469,8 +3473,8 @@ dependencies = [
 
 [[package]]
 name = "iota-rest-api"
-version = "1.18.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+version = "1.19.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "anyhow",
  "axum",
@@ -3529,8 +3533,8 @@ dependencies = [
 
 [[package]]
 name = "iota-sdk"
-version = "1.18.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+version = "1.19.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3588,8 +3592,8 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-builder"
-version = "1.18.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+version = "1.19.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3605,8 +3609,8 @@ dependencies = [
 
 [[package]]
 name = "iota-types"
-version = "1.18.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+version = "1.19.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "anemo",
  "anyhow",
@@ -3660,8 +3664,8 @@ dependencies = [
  "signature 1.6.4",
  "starfish-config",
  "static_assertions",
- "strum 0.26.3",
- "strum_macros 0.26.4",
+ "strum 0.27.2",
+ "strum_macros 0.27.2",
  "tap",
  "thiserror 1.0.69",
  "tonic",
@@ -3672,7 +3676,7 @@ dependencies = [
 [[package]]
 name = "iota-verifier-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "bcs",
  "iota-types",
@@ -3687,8 +3691,8 @@ dependencies = [
 
 [[package]]
 name = "iota_interaction"
-version = "0.8.13"
-source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.13#900b595592d2d8b320ff3de00683b1392eb1cc4d"
+version = "0.8.14"
+source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.14#c18bea2bdd3f4d1ff6a5606fd8d5d03b0a6b4862"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3702,7 +3706,7 @@ dependencies = [
  "hex",
  "hyper",
  "indexmap 2.12.1",
- "iota-sdk 1.18.1",
+ "iota-sdk 1.19.1",
  "iota-sdk-types",
  "itertools 0.13.0",
  "jsonpath-rust",
@@ -3730,8 +3734,8 @@ dependencies = [
 
 [[package]]
 name = "iota_interaction_rust"
-version = "0.8.13"
-source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.13#900b595592d2d8b320ff3de00683b1392eb1cc4d"
+version = "0.8.14"
+source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.14#c18bea2bdd3f4d1ff6a5606fd8d5d03b0a6b4862"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3743,8 +3747,8 @@ dependencies = [
 
 [[package]]
 name = "iota_interaction_ts"
-version = "0.8.13"
-source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.13#900b595592d2d8b320ff3de00683b1392eb1cc4d"
+version = "0.8.14"
+source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.14#c18bea2bdd3f4d1ff6a5606fd8d5d03b0a6b4862"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4366,7 +4370,7 @@ dependencies = [
 [[package]]
 name = "move-abstract-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "move-binary-format",
  "move-bytecode-verifier-meter",
@@ -4375,12 +4379,12 @@ dependencies = [
 [[package]]
 name = "move-abstract-stack"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "anyhow",
  "enum-compat-util",
@@ -4395,12 +4399,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4416,7 +4420,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "anyhow",
  "indexmap 2.12.1",
@@ -4430,7 +4434,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -4445,7 +4449,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-meter"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -4455,7 +4459,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4475,7 +4479,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4510,7 +4514,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4534,7 +4538,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4555,7 +4559,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4576,7 +4580,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -4594,7 +4598,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "anyhow",
  "hex",
@@ -4607,7 +4611,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -4620,7 +4624,7 @@ dependencies = [
 [[package]]
 name = "move-proc-macros"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "quote",
  "syn 2.0.111",
@@ -4629,7 +4633,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives"
 version = "0.1.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -4644,7 +4648,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "once_cell",
  "phf",
@@ -4654,7 +4658,7 @@ dependencies = [
 [[package]]
 name = "move-trace-format"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -4665,7 +4669,7 @@ dependencies = [
 [[package]]
 name = "move-vm-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "move-binary-format",
  "once_cell",
@@ -4674,7 +4678,7 @@ dependencies = [
 [[package]]
 name = "move-vm-profiler"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "move-vm-config",
  "once_cell",
@@ -4684,7 +4688,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "better_any",
  "fail",
@@ -4704,7 +4708,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -4718,7 +4722,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -5756,8 +5760,8 @@ dependencies = [
 
 [[package]]
 name = "product_common"
-version = "0.8.13"
-source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.13#900b595592d2d8b320ff3de00683b1392eb1cc4d"
+version = "0.8.14"
+source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.14#c18bea2bdd3f4d1ff6a5606fd8d5d03b0a6b4862"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5766,7 +5770,7 @@ dependencies = [
  "fastcrypto",
  "hyper",
  "iota-keys",
- "iota-sdk 1.18.1",
+ "iota-sdk 1.19.1",
  "iota-sdk-types",
  "iota_interaction",
  "iota_interaction_rust",
@@ -5802,8 +5806,8 @@ dependencies = [
 
 [[package]]
 name = "prometheus-closure-metric"
-version = "1.18.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+version = "1.19.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -7170,7 +7174,7 @@ dependencies = [
 [[package]]
 name = "starfish-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "blake3",
  "fastcrypto",
@@ -7179,6 +7183,7 @@ dependencies = [
  "rand 0.8.5",
  "rs_merkle",
  "serde",
+ "tracing",
 ]
 
 [[package]]
@@ -7268,15 +7273,6 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-dependencies = [
- "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
@@ -7291,19 +7287,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
  "heck 0.4.1",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.111",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -7975,8 +7958,8 @@ dependencies = [
 
 [[package]]
 name = "typed-store-error"
-version = "1.18.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.18.1#b33d5fe5d0be1ff0ce66e904a71e67de6781d06c"
+version = "1.19.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.19.1#fa39361cc6382e962c3ca059e773d76d19373b85"
 dependencies = [
  "serde",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,7 @@ product_common = { package = "product_common", git = "https://github.com/iotaled
 secret-storage = { git = "https://github.com/iotaledger/secret-storage", tag = "v0.3.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.149"
-strum = { version = "0.27", default-features = false, features = [
-  "derive",
-  "std",
-] }
+strum = { version = "0.27", default-features = false, features = ["derive", "std"] }
 thiserror = "2.0"
 tokio = { version = "1.49.0", default-features = false, features = ["sync"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,15 +17,18 @@ async-trait = "0.1"
 bcs = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 hyper = "1.8"
-iota-sdk = { package = "iota-sdk", git = "https://github.com/iotaledger/iota.git", tag = "v1.18.1" }
-iota_interaction = { package = "iota_interaction", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.13", default-features = false }
-iota_interaction_rust = { package = "iota_interaction_rust", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.13", default-features = false }
-iota_interaction_ts = { package = "iota_interaction_ts", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.13", default-features = false }
-product_common = { package = "product_common", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.13", default-features = false }
+iota-sdk = { package = "iota-sdk", git = "https://github.com/iotaledger/iota.git", tag = "v1.19.1" }
+iota_interaction = { package = "iota_interaction", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.14", default-features = false }
+iota_interaction_rust = { package = "iota_interaction_rust", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.14", default-features = false }
+iota_interaction_ts = { package = "iota_interaction_ts", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.14", default-features = false }
+product_common = { package = "product_common", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.14", default-features = false }
 secret-storage = { git = "https://github.com/iotaledger/secret-storage", tag = "v0.3.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.149"
-strum = { version = "0.27", default-features = false, features = ["derive", "std"] }
+strum = { version = "0.27", default-features = false, features = [
+  "derive",
+  "std",
+] }
 thiserror = "2.0"
 tokio = { version = "1.49.0", default-features = false, features = ["sync"] }
 

--- a/bindings/wasm/hierarchies_wasm/Cargo.toml
+++ b/bindings/wasm/hierarchies_wasm/Cargo.toml
@@ -52,9 +52,7 @@ empty_docs = "allow"
 
 [lints.rust]
 # required for current wasm_bindgen version
-unexpected_cfgs = { level = "warn", check-cfg = [
-  "cfg(wasm_bindgen_unstable_test_coverage)",
-] }
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(wasm_bindgen_unstable_test_coverage)"] }
 
 [profile.release]
 opt-level = "s"

--- a/bindings/wasm/hierarchies_wasm/Cargo.toml
+++ b/bindings/wasm/hierarchies_wasm/Cargo.toml
@@ -19,8 +19,8 @@ crate-type = ["cdylib", "rlib"]
 anyhow = "1.0"
 console_error_panic_hook = "0.1"
 hyper = "1.8"
-iota_interaction = { package = "iota_interaction", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.13", default-features = false }
-iota_interaction_ts = { package = "iota_interaction_ts", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.13" }
+iota_interaction = { package = "iota_interaction", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.14", default-features = false }
+iota_interaction_ts = { package = "iota_interaction_ts", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.14" }
 js-sys = { version = "=0.3.85" }
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6"
@@ -35,7 +35,7 @@ features = ["default-http-client", "gas-station"]
 [dependencies.product_common]
 package = "product_common"
 git = "https://github.com/iotaledger/product-core.git"
-tag = "v0.8.13"
+tag = "v0.8.14"
 features = [
   "default-http-client",
   "binding-utils",
@@ -52,7 +52,9 @@ empty_docs = "allow"
 
 [lints.rust]
 # required for current wasm_bindgen version
-unexpected_cfgs = { level = "warn", check-cfg = ["cfg(wasm_bindgen_unstable_test_coverage)"] }
+unexpected_cfgs = { level = "warn", check-cfg = [
+  "cfg(wasm_bindgen_unstable_test_coverage)",
+] }
 
 [profile.release]
 opt-level = "s"


### PR DESCRIPTION
# Description of change

Following dependencies have been changed:
- [ ] tokio version update to: -
- [ ] fastcrypto version update to rev = "-"
- [ ] iota-sdk-types (`https://github.com/iotaledger/iota-rust-sdk.git`) update to rev = -
- [ ] notarization_wasm: new peerDep. version for @iota/iota-sdk: _
- [ ] notarization_wasm: new dependency version for @iota/iota-interaction-ts: _
- [x] pin all product-core.git dependencies to `tag = "v0.8.14"`
- [x] pin all iota.git dependencies to `tag = "v1.19.1"`

## Links to any relevant issues
https://github.com/iotaledger/product-core/issues/67