### PR TITLE
fix: printing the panic message into the console

### DIFF
--- a/bindings/wasm/hierarchies_wasm/src/lib.rs
+++ b/bindings/wasm/hierarchies_wasm/src/lib.rs
@@ -27,6 +27,7 @@ extern "C" {
 /// Initializes the console error panic hook for better error messages
 #[wasm_bindgen(start)]
 pub fn start() -> Result<(), JsValue> {
+    #[cfg(debug_assertions)]
     console_error_panic_hook::set_once();
     Ok(())
 }


### PR DESCRIPTION
# Description of change

Removes error messages that appear in the browser console when using the release build. 
closes #178 

## Type of change


- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

## How the change has been tested

<!-- Describe the tests that you ran to verify your changes. -->

manual check

## Change checklist

<!-- Tick the boxes that are relevant to your changes, and delete any items that are not. -->

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md, if my changes are significant enough
