### PR TITLE
feat: Update to iota 96196f0 - yanked core2 fix for v1.21.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,7 +472,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
- "synstructure 0.13.2",
+ "synstructure",
 ]
 
 [[package]]
@@ -1199,7 +1199,7 @@ dependencies = [
 [[package]]
 name = "consensus-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "fastcrypto",
  "iota-network-stack",
@@ -1875,7 +1875,7 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 [[package]]
 name = "enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "serde_yaml",
 ]
@@ -2644,7 +2644,7 @@ dependencies = [
  "chrono",
  "hierarchies",
  "hyper",
- "iota-sdk 1.20.1",
+ "iota-sdk 1.22.0-alpha",
  "product_common",
  "tokio",
 ]
@@ -3064,10 +3064,11 @@ dependencies = [
 [[package]]
 name = "iota-adapter-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "anyhow",
  "bcs",
+ "iota-common",
  "iota-macros",
  "iota-metrics",
  "iota-move-natives-latest",
@@ -3091,8 +3092,8 @@ dependencies = [
 
 [[package]]
 name = "iota-common"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.22.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -3102,7 +3103,6 @@ dependencies = [
  "iota-types",
  "once_cell",
  "parking_lot 0.12.5",
- "prometheus",
  "rand 0.8.5",
  "reqwest 0.12.26",
  "snap",
@@ -3113,8 +3113,8 @@ dependencies = [
 
 [[package]]
 name = "iota-config"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.22.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "anemo",
  "anyhow",
@@ -3127,7 +3127,6 @@ dependencies = [
  "iota-genesis-common",
  "iota-keys",
  "iota-names",
- "iota-rest-api",
  "iota-types",
  "move-vm-config",
  "object_store",
@@ -3178,8 +3177,8 @@ dependencies = [
 
 [[package]]
 name = "iota-enum-compat-util"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.22.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "serde_yaml",
 ]
@@ -3187,7 +3186,7 @@ dependencies = [
 [[package]]
 name = "iota-execution"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "iota-adapter-latest",
  "iota-move-natives-latest",
@@ -3204,8 +3203,8 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-common"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.22.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "iota-execution",
  "iota-protocol-config",
@@ -3215,8 +3214,8 @@ dependencies = [
 
 [[package]]
 name = "iota-http"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.22.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "bytes",
  "http",
@@ -3236,8 +3235,8 @@ dependencies = [
 
 [[package]]
 name = "iota-json"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.22.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3253,8 +3252,8 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-api"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.22.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -3273,8 +3272,8 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-types"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.22.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3308,8 +3307,8 @@ dependencies = [
 
 [[package]]
 name = "iota-keys"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.22.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "anyhow",
  "bip32",
@@ -3329,8 +3328,8 @@ dependencies = [
 
 [[package]]
 name = "iota-macros"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.22.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "futures",
  "iota-proc-macros",
@@ -3340,8 +3339,8 @@ dependencies = [
 
 [[package]]
 name = "iota-metrics"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.22.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -3367,7 +3366,7 @@ dependencies = [
 [[package]]
 name = "iota-move-natives-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "bcs",
  "better_any",
@@ -3390,8 +3389,8 @@ dependencies = [
 
 [[package]]
 name = "iota-names"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.22.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3403,8 +3402,8 @@ dependencies = [
 
 [[package]]
 name = "iota-network-stack"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.22.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "anemo",
  "bcs",
@@ -3433,8 +3432,8 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.22.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -3444,8 +3443,8 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc-macros"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.22.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -3457,8 +3456,8 @@ dependencies = [
 
 [[package]]
 name = "iota-package-resolver"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.22.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "async-trait",
  "bcs",
@@ -3473,8 +3472,8 @@ dependencies = [
 
 [[package]]
 name = "iota-proc-macros"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.22.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "msim-macros",
  "proc-macro2",
@@ -3484,8 +3483,8 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.22.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "clap",
  "iota-protocol-config-macros",
@@ -3499,39 +3498,12 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config-macros"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.22.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "iota-rest-api"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
-dependencies = [
- "anyhow",
- "axum",
- "bcs",
- "fastcrypto",
- "iota-network-stack",
- "iota-protocol-config",
- "iota-sdk-types",
- "iota-types",
- "itertools 0.13.0",
- "mime",
- "move-binary-format",
- "openapiv3",
- "prometheus",
- "schemars 0.8.22",
- "serde",
- "serde_json",
- "serde_with",
- "serde_yaml",
- "tap",
- "tokio",
 ]
 
 [[package]]
@@ -3567,8 +3539,8 @@ dependencies = [
 
 [[package]]
 name = "iota-sdk"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.22.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3626,8 +3598,8 @@ dependencies = [
 
 [[package]]
 name = "iota-tls"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.22.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3648,8 +3620,8 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-builder"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.22.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3665,8 +3637,8 @@ dependencies = [
 
 [[package]]
 name = "iota-types"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.22.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "anemo",
  "anyhow",
@@ -3731,7 +3703,7 @@ dependencies = [
 [[package]]
 name = "iota-verifier-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "bcs",
  "iota-types",
@@ -3746,8 +3718,8 @@ dependencies = [
 
 [[package]]
 name = "iota_interaction"
-version = "0.8.15"
-source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.15#effb4d0051462bc6fc7bf3ba2f7252aa2e3e92a3"
+version = "0.8.16"
+source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.16#1d3480d6536cdf9152e754a4d1c7474438785f4a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3761,7 +3733,7 @@ dependencies = [
  "hex",
  "hyper",
  "indexmap 2.12.1",
- "iota-sdk 1.20.1",
+ "iota-sdk 1.22.0-alpha",
  "iota-sdk-types",
  "itertools 0.13.0",
  "jsonpath-rust",
@@ -3789,8 +3761,8 @@ dependencies = [
 
 [[package]]
 name = "iota_interaction_rust"
-version = "0.8.15"
-source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.15#effb4d0051462bc6fc7bf3ba2f7252aa2e3e92a3"
+version = "0.8.16"
+source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.16#1d3480d6536cdf9152e754a4d1c7474438785f4a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3802,8 +3774,8 @@ dependencies = [
 
 [[package]]
 name = "iota_interaction_ts"
-version = "0.8.15"
-source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.15#effb4d0051462bc6fc7bf3ba2f7252aa2e3e92a3"
+version = "0.8.16"
+source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.16#1d3480d6536cdf9152e754a4d1c7474438785f4a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4235,6 +4207,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
+name = "libp2p-identity"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c7892c221730ba55f7196e98b0b8ba5e04b4155651736036628e9f73ed6fc3"
+dependencies = [
+ "bs58 0.5.1",
+ "hkdf",
+ "multihash",
+ "sha2 0.10.9",
+ "thiserror 2.0.17",
+ "tracing",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4425,7 +4411,7 @@ dependencies = [
 [[package]]
 name = "move-abstract-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "move-binary-format",
  "move-bytecode-verifier-meter",
@@ -4434,12 +4420,12 @@ dependencies = [
 [[package]]
 name = "move-abstract-stack"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "anyhow",
  "enum-compat-util",
@@ -4454,12 +4440,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4475,7 +4461,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "anyhow",
  "indexmap 2.12.1",
@@ -4489,7 +4475,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -4497,6 +4483,7 @@ dependencies = [
  "move-borrow-graph",
  "move-bytecode-verifier-meter",
  "move-core-types",
+ "move-regex-borrow-graph",
  "move-vm-config",
  "petgraph",
 ]
@@ -4504,7 +4491,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-meter"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -4514,7 +4501,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4534,7 +4521,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4569,7 +4556,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4593,7 +4580,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4614,7 +4601,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4635,7 +4622,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -4653,7 +4640,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "anyhow",
  "hex",
@@ -4666,7 +4653,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -4679,16 +4666,26 @@ dependencies = [
 [[package]]
 name = "move-proc-macros"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "quote",
  "syn 2.0.111",
 ]
 
 [[package]]
+name = "move-regex-borrow-graph"
+version = "0.0.1"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+dependencies = [
+ "move-binary-format",
+ "move-core-types",
+ "petgraph",
+]
+
+[[package]]
 name = "move-stdlib-natives"
 version = "0.1.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -4703,7 +4700,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "once_cell",
  "phf",
@@ -4713,7 +4710,7 @@ dependencies = [
 [[package]]
 name = "move-trace-format"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -4724,7 +4721,7 @@ dependencies = [
 [[package]]
 name = "move-vm-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "move-binary-format",
  "once_cell",
@@ -4733,7 +4730,7 @@ dependencies = [
 [[package]]
 name = "move-vm-profiler"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "move-vm-config",
  "once_cell",
@@ -4743,7 +4740,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "better_any",
  "fail",
@@ -4763,7 +4760,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -4777,7 +4774,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -4800,14 +4797,14 @@ dependencies = [
 
 [[package]]
 name = "multiaddr"
-version = "0.17.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b36f567c7099511fa8612bbbb52dda2419ce0bdbacf31714e3a5ffdb766d3bd"
+checksum = "fe6351f60b488e04c1d21bc69e56b89cb3f5e8f5d22557d6e8031bdfd79b6961"
 dependencies = [
  "arrayref",
  "byteorder",
  "data-encoding",
- "log",
+ "libp2p-identity",
  "multibase",
  "multihash",
  "percent-encoding",
@@ -4831,27 +4828,11 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.17.0"
+version = "0.19.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835d6ff01d610179fbce3de1694d007e500bf33a7f29689838941d6bf783ae40"
+checksum = "577c63b00ad74d57e8c9aa870b5fccebf2fd64a308a5aee9f1bb88e4aea19447"
 dependencies = [
- "core2",
- "multihash-derive",
  "unsigned-varint",
-]
-
-[[package]]
-name = "multihash-derive"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc076939022111618a5026d3be019fd8b366e76314538ff9a1b59ffbcbf98bcd"
-dependencies = [
- "proc-macro-crate 1.3.1",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "synstructure 0.12.6",
 ]
 
 [[package]]
@@ -5150,17 +5131,6 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
-name = "openapiv3"
-version = "2.0.0"
-source = "git+https://github.com/bmwill/openapiv3.git?rev=ca4b4845b7c159a39f5c68ad8f7f76cb6f4d6963#ca4b4845b7c159a39f5c68ad8f7f76cb6f4d6963"
-dependencies = [
- "indexmap 2.12.1",
- "schemars 0.8.22",
- "serde",
- "serde_json",
-]
 
 [[package]]
 name = "openssl-probe"
@@ -5815,8 +5785,8 @@ dependencies = [
 
 [[package]]
 name = "product_common"
-version = "0.8.15"
-source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.15#effb4d0051462bc6fc7bf3ba2f7252aa2e3e92a3"
+version = "0.8.16"
+source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.16#1d3480d6536cdf9152e754a4d1c7474438785f4a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5825,7 +5795,7 @@ dependencies = [
  "fastcrypto",
  "hyper",
  "iota-keys",
- "iota-sdk 1.20.1",
+ "iota-sdk 1.22.0-alpha",
  "iota-sdk-types",
  "iota_interaction",
  "iota_interaction_rust",
@@ -5861,8 +5831,8 @@ dependencies = [
 
 [[package]]
 name = "prometheus-closure-metric"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.22.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -7217,7 +7187,7 @@ dependencies = [
 [[package]]
 name = "starfish-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "blake3",
  "fastcrypto",
@@ -7389,18 +7359,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 dependencies = [
  "futures-core",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "unicode-xid",
 ]
 
 [[package]]
@@ -8001,8 +7959,8 @@ dependencies = [
 
 [[package]]
 name = "typed-store-error"
-version = "1.20.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.1#4b42f54d49b9356b1a2f659eaed324bf986a3c13"
+version = "1.22.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
 dependencies = [
  "serde",
  "thiserror 1.0.69",
@@ -8105,9 +8063,9 @@ dependencies = [
 
 [[package]]
 name = "unsigned-varint"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
+checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
 
 [[package]]
 name = "untrusted"
@@ -8986,7 +8944,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
- "synstructure 0.13.2",
+ "synstructure",
 ]
 
 [[package]]
@@ -9027,7 +8985,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
- "synstructure 0.13.2",
+ "synstructure",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,7 @@ product_common = { package = "product_common", git = "https://github.com/iotaled
 secret-storage = { git = "https://github.com/iotaledger/secret-storage", tag = "v0.3.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.149"
-strum = { version = "0.27", default-features = false, features = [
-  "derive",
-  "std",
-] }
+strum = { version = "0.27", default-features = false, features = ["derive", "std"] }
 thiserror = "2.0"
 tokio = { version = "1.49.0", default-features = false, features = ["sync"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,15 +17,18 @@ async-trait = "0.1"
 bcs = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 hyper = "1.8"
-iota-sdk = { package = "iota-sdk", git = "https://github.com/iotaledger/iota.git", tag = "v1.20.1" }
-iota_interaction = { package = "iota_interaction", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.15", default-features = false }
-iota_interaction_rust = { package = "iota_interaction_rust", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.15", default-features = false }
-iota_interaction_ts = { package = "iota_interaction_ts", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.15", default-features = false }
-product_common = { package = "product_common", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.15", default-features = false }
+iota-sdk = { package = "iota-sdk", git = "https://github.com/iotaledger/iota.git", rev = "96196f0da231883ec69cda04892c600ef6afa982" }
+iota_interaction = { package = "iota_interaction", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.16", default-features = false }
+iota_interaction_rust = { package = "iota_interaction_rust", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.16", default-features = false }
+iota_interaction_ts = { package = "iota_interaction_ts", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.16", default-features = false }
+product_common = { package = "product_common", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.16", default-features = false }
 secret-storage = { git = "https://github.com/iotaledger/secret-storage", tag = "v0.3.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.149"
-strum = { version = "0.27", default-features = false, features = ["derive", "std"] }
+strum = { version = "0.27", default-features = false, features = [
+  "derive",
+  "std",
+] }
 thiserror = "2.0"
 tokio = { version = "1.49.0", default-features = false, features = ["sync"] }
 

--- a/bindings/wasm/hierarchies_wasm/Cargo.toml
+++ b/bindings/wasm/hierarchies_wasm/Cargo.toml
@@ -52,9 +52,7 @@ empty_docs = "allow"
 
 [lints.rust]
 # required for current wasm_bindgen version
-unexpected_cfgs = { level = "warn", check-cfg = [
-  "cfg(wasm_bindgen_unstable_test_coverage)",
-] }
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(wasm_bindgen_unstable_test_coverage)"] }
 
 [profile.release]
 opt-level = "s"

--- a/bindings/wasm/hierarchies_wasm/Cargo.toml
+++ b/bindings/wasm/hierarchies_wasm/Cargo.toml
@@ -19,8 +19,8 @@ crate-type = ["cdylib", "rlib"]
 anyhow = "1.0"
 console_error_panic_hook = "0.1"
 hyper = "1.8"
-iota_interaction = { package = "iota_interaction", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.15", default-features = false }
-iota_interaction_ts = { package = "iota_interaction_ts", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.15" }
+iota_interaction = { package = "iota_interaction", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.16", default-features = false }
+iota_interaction_ts = { package = "iota_interaction_ts", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.16" }
 js-sys = { version = "=0.3.85" }
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6"
@@ -35,7 +35,7 @@ features = ["default-http-client", "gas-station"]
 [dependencies.product_common]
 package = "product_common"
 git = "https://github.com/iotaledger/product-core.git"
-tag = "v0.8.15"
+tag = "v0.8.16"
 features = [
   "default-http-client",
   "binding-utils",
@@ -52,7 +52,9 @@ empty_docs = "allow"
 
 [lints.rust]
 # required for current wasm_bindgen version
-unexpected_cfgs = { level = "warn", check-cfg = ["cfg(wasm_bindgen_unstable_test_coverage)"] }
+unexpected_cfgs = { level = "warn", check-cfg = [
+  "cfg(wasm_bindgen_unstable_test_coverage)",
+] }
 
 [profile.release]
 opt-level = "s"

--- a/bindings/wasm/hierarchies_wasm/package-lock.json
+++ b/bindings/wasm/hierarchies_wasm/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.1.9",
             "license": "Apache-2.0",
             "dependencies": {
-                "@iota/iota-interaction-ts": "^0.12.0"
+                "@iota/iota-interaction-ts": "^0.13.0"
             },
             "devDependencies": {
                 "@types/lodash": "^4.17.20",
@@ -37,7 +37,7 @@
                 "node": ">=20"
             },
             "peerDependencies": {
-                "@iota/iota-sdk": "^1.11.0"
+                "@iota/iota-sdk": "^1.13.0"
             }
         },
         "node_modules/@0no-co/graphql.web": {
@@ -56,9 +56,9 @@
             }
         },
         "node_modules/@0no-co/graphqlsp": {
-            "version": "1.15.2",
-            "resolved": "https://registry.npmjs.org/@0no-co/graphqlsp/-/graphqlsp-1.15.2.tgz",
-            "integrity": "sha512-Ys031WnS3sTQQBtRTkQsYnw372OlW72ais4sp0oh2UMPRNyxxnq85zRfU4PIdoy9kWriysPT5BYAkgIxhbonFA==",
+            "version": "1.15.4",
+            "resolved": "https://registry.npmjs.org/@0no-co/graphqlsp/-/graphqlsp-1.15.4.tgz",
+            "integrity": "sha512-Nt1DVHcZ08lKRKwhiU0amXH77fSdrO6DzyjLE0DkCxfbM/N1SAs32d76y1xtCzM5H9eT0iDS7SdksgRXWJu05g==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -67,7 +67,7 @@
             },
             "peerDependencies": {
                 "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
-                "typescript": "^5.0.0"
+                "typescript": "^5.0.0 || ^6.0.0"
             }
         },
         "node_modules/@babel/helper-string-parser": {
@@ -199,22 +199,22 @@
             }
         },
         "node_modules/@gql.tada/cli-utils": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/@gql.tada/cli-utils/-/cli-utils-1.7.2.tgz",
-            "integrity": "sha512-Qbc7hbLvCz6IliIJpJuKJa9p05b2Jona7ov7+qofCsMRxHRZE1kpAmZMvL8JCI4c0IagpIlWNaMizXEQUe8XjQ==",
+            "version": "1.7.3",
+            "resolved": "https://registry.npmjs.org/@gql.tada/cli-utils/-/cli-utils-1.7.3.tgz",
+            "integrity": "sha512-3iQY5E/jvv3Lnh6D1Mh7zr+Bb9C/TGk1DHkm+lbIjQBnZAu2m+BcTcr1e3spUt6Aa6HG/xAN2XxpbWw9oZALEg==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@0no-co/graphqlsp": "^1.12.13",
-                "@gql.tada/internal": "1.0.8",
+                "@gql.tada/internal": "1.0.9",
                 "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0"
             },
             "peerDependencies": {
                 "@0no-co/graphqlsp": "^1.12.13",
-                "@gql.tada/svelte-support": "1.0.1",
-                "@gql.tada/vue-support": "1.0.1",
+                "@gql.tada/svelte-support": "1.0.2",
+                "@gql.tada/vue-support": "1.0.2",
                 "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
-                "typescript": "^5.0.0"
+                "typescript": "^5.0.0 || ^6.0.0"
             },
             "peerDependenciesMeta": {
                 "@gql.tada/svelte-support": {
@@ -226,9 +226,9 @@
             }
         },
         "node_modules/@gql.tada/internal": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/@gql.tada/internal/-/internal-1.0.8.tgz",
-            "integrity": "sha512-XYdxJhtHC5WtZfdDqtKjcQ4d7R1s0d1rnlSs3OcBEUbYiPoJJfZU7tWsVXuv047Z6msvmr4ompJ7eLSK5Km57g==",
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@gql.tada/internal/-/internal-1.0.9.tgz",
+            "integrity": "sha512-Bp8yi+kLrzIJ3l5Dfxhz48H4OCH2LCX+pShaPcJgh+oiBt6clrjUKDYNDD3Z78aDQ3+Tyrxe4dd0MfLgpSLPPg==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -236,7 +236,7 @@
             },
             "peerDependencies": {
                 "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
-                "typescript": "^5.0.0"
+                "typescript": "^5.0.0 || ^6.0.0"
             }
         },
         "node_modules/@graphql-typed-document-node/core": {
@@ -267,9 +267,9 @@
             }
         },
         "node_modules/@iota/bcs": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@iota/bcs/-/bcs-1.5.0.tgz",
-            "integrity": "sha512-/hv395YtUcRNLY00v7Cl2O+KvVUaUajg4OucZENgSE4Xu1ygUGsLD3dU5FixOUVOn7Abo+n7+KYr9PE/1dsvWg==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/@iota/bcs/-/bcs-1.6.0.tgz",
+            "integrity": "sha512-H8I9g+aPBQigSsHkydnnR6wmmTwOwI7iu/TghTOz6tikqVFM09cA2JlDQXRLDTSkW3Qlz6gONyVKzrBhoTkHxQ==",
             "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
@@ -277,26 +277,26 @@
             }
         },
         "node_modules/@iota/iota-interaction-ts": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/@iota/iota-interaction-ts/-/iota-interaction-ts-0.12.0.tgz",
-            "integrity": "sha512-qGGn7DMpzDHCzdrvV4QWUXE1u/5UzX5Y7pWX9RNGkhlerD7gPk01abf4XjfmEhRkN3S2L7YBpnXK34LA6ZzC9w==",
+            "version": "0.13.0",
+            "resolved": "https://registry.npmjs.org/@iota/iota-interaction-ts/-/iota-interaction-ts-0.13.0.tgz",
+            "integrity": "sha512-LL4nbgEbqqa3UqXkiAnbRMW3KSqKMic0cJEEooWlTz2VtwHSOHyVwzjF2HNt7C9o2svq5uKyCkkzVAxjMI1Esg==",
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=20"
             },
             "peerDependencies": {
-                "@iota/iota-sdk": "^1.11.0"
+                "@iota/iota-sdk": "^1.13.0"
             }
         },
         "node_modules/@iota/iota-sdk": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@iota/iota-sdk/-/iota-sdk-1.11.0.tgz",
-            "integrity": "sha512-Fveg/4euheaBUzU1ybPyFGe7sSfLFUjLNHhPjNFUmSBOMR+l9q3LU1QdN2sLElcmgJZ+BLxAEmL8TZ0eX3Khpw==",
+            "version": "1.13.0",
+            "resolved": "https://registry.npmjs.org/@iota/iota-sdk/-/iota-sdk-1.13.0.tgz",
+            "integrity": "sha512-ay19PRu0z+1W9tnmGyexIR/Sp0Rpt7H0mUCuEZQ5B+7O6Qf61+Co8TrR1SRIrKwD7Fu90jPy5y5MwFXy/vLwKg==",
             "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
                 "@graphql-typed-document-node/core": "^3.2.0",
-                "@iota/bcs": "1.5.0",
+                "@iota/bcs": "1.6.0",
                 "@noble/curves": "^1.4.2",
                 "@noble/hashes": "^1.4.0",
                 "@scure/base": "^1.2.4",
@@ -3379,23 +3379,23 @@
             }
         },
         "node_modules/gql.tada": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/gql.tada/-/gql.tada-1.9.0.tgz",
-            "integrity": "sha512-1LMiA46dRs5oF7Qev6vMU32gmiNvM3+3nHoQZA9K9j2xQzH8xOAWnnJrLSbZOFHTSdFxqn86TL6beo1/7ja/aA==",
+            "version": "1.9.2",
+            "resolved": "https://registry.npmjs.org/gql.tada/-/gql.tada-1.9.2.tgz",
+            "integrity": "sha512-QxRHVpxtrOVdYXz6oavq0lBM+Zdp0swapLGJcD4SLpXDcsD337BHDFrzqqjfkbepv0sSAiO0LGabu1kI5D5Gyg==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@0no-co/graphql.web": "^1.0.5",
                 "@0no-co/graphqlsp": "^1.12.13",
-                "@gql.tada/cli-utils": "1.7.2",
-                "@gql.tada/internal": "1.0.8"
+                "@gql.tada/cli-utils": "1.7.3",
+                "@gql.tada/internal": "1.0.9"
             },
             "bin": {
                 "gql-tada": "bin/cli.js",
                 "gql.tada": "bin/cli.js"
             },
             "peerDependencies": {
-                "typescript": "^5.0.0"
+                "typescript": "^5.0.0 || ^6.0.0"
             }
         },
         "node_modules/graceful-fs": {
@@ -3406,9 +3406,9 @@
             "license": "ISC"
         },
         "node_modules/graphql": {
-            "version": "16.13.0",
-            "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.0.tgz",
-            "integrity": "sha512-uSisMYERbaB9bkA9M4/4dnqyktaEkf1kMHNKq/7DHyxVeWqHQ2mBmVqm5u6/FVHwF3iCNalKcg82Zfl+tffWoA==",
+            "version": "16.13.2",
+            "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
+            "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
             "license": "MIT",
             "peer": true,
             "engines": {
@@ -7251,9 +7251,9 @@
             "license": "MIT"
         },
         "node_modules/valibot": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.2.0.tgz",
-            "integrity": "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.3.1.tgz",
+            "integrity": "sha512-sfdRir/QFM0JaF22hqTroPc5xy4DimuGQVKFrzF1YfGwaS1nJot3Y8VqMdLO2Lg27fMzat2yD3pY5PbAYO39Gg==",
             "license": "MIT",
             "peer": true,
             "peerDependencies": {

--- a/bindings/wasm/hierarchies_wasm/package.json
+++ b/bindings/wasm/hierarchies_wasm/package.json
@@ -74,10 +74,10 @@
         "wasm-opt": "^1.4.0"
     },
     "dependencies": {
-        "@iota/iota-interaction-ts": "^0.12.0"
+        "@iota/iota-interaction-ts": "^0.13.0"
     },
     "peerDependencies": {
-        "@iota/iota-sdk": "^1.11.0"
+        "@iota/iota-sdk": "^1.13.0"
     },
     "engines": {
         "node": ">=20"

--- a/hierarchies-move/Move.history.json
+++ b/hierarchies-move/Move.history.json
@@ -5,14 +5,14 @@
     "testnet": "2304aa97"
   },
   "envs": {
+    "2304aa97": [
+      "0xbaa47178b92a43d08f79c029a385d5aff75e4e1010e12ea5105fe68f4e9ce8ef"
+    ],
     "daf90477": [
       "0x0de31a24502b692a1f1984697ad45043f5dbdf3169283aa20d08805a11b20368"
     ],
     "6364aad5": [
       "0x0f75165f01198edbc758df00d61440a46300efb639f3a5c33a7c797a8a66d371"
-    ],
-    "2304aa97": [
-      "0xbaa47178b92a43d08f79c029a385d5aff75e4e1010e12ea5105fe68f4e9ce8ef"
     ]
   }
 }

--- a/hierarchies-move/Move.history.json
+++ b/hierarchies-move/Move.history.json
@@ -5,14 +5,14 @@
     "testnet": "2304aa97"
   },
   "envs": {
-    "2304aa97": [
-      "0xbaa47178b92a43d08f79c029a385d5aff75e4e1010e12ea5105fe68f4e9ce8ef"
-    ],
     "daf90477": [
       "0x0de31a24502b692a1f1984697ad45043f5dbdf3169283aa20d08805a11b20368"
     ],
     "6364aad5": [
       "0x0f75165f01198edbc758df00d61440a46300efb639f3a5c33a7c797a8a66d371"
+    ],
+    "2304aa97": [
+      "0xbaa47178b92a43d08f79c029a385d5aff75e4e1010e12ea5105fe68f4e9ce8ef"
     ]
   }
 }


### PR DESCRIPTION
# Description of change

Following dependencies have been changed:
- [ ] tokio version update to: -
- [ ] fastcrypto version update to rev = "-"
- [ ] iota-sdk-types (`[https://github.com/iotaledger/iota-rust-sdk.git`](https://github.com/iotaledger/iota-rust-sdk.git%60)) update to rev = -
- [x] hierarchies_wasm: new peerDep. version for @iota/iota-sdk: "^1.13.0"
- [x] hierarchies_wasm: new dependency version for @iota/iota-interaction-ts: "^0.13.0"
- [x] pin all product-core.git dependencies to `tag = "v0.8.16"`
- [x] pin all iota.git dependencies to `rev = "96196f0da231883ec69cda04892c600ef6afa982"`

## Links to any relevant issues
https://github.com/iotaledger/product-core/issues/67