### PR TITLE
Release: Version 0.1.16-alpha and npmjs version 0.1.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2618,7 +2618,7 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hierarchies"
-version = "0.1.15-alpha"
+version = "0.1.16-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2638,7 +2638,7 @@ dependencies = [
 
 [[package]]
 name = "hierarchies_examples"
-version = "0.1.15-alpha"
+version = "0.1.16-alpha"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,7 @@ product_common = { package = "product_common", git = "https://github.com/iotaled
 secret-storage = { git = "https://github.com/iotaledger/secret-storage", tag = "v0.3.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.149"
-strum = { version = "0.27", default-features = false, features = [
-  "derive",
-  "std",
-] }
+strum = { version = "0.27", default-features = false, features = ["derive", "std"] }
 thiserror = "2.0"
 tokio = { version = "1.49.0", default-features = false, features = ["sync"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["hierarchies-rs/examples", "hierarchies-rs/hierarchies"]
 exclude = ["bindings/wasm/hierarchies_wasm"]
 
 [workspace.package]
-version = "0.1.15-alpha"
+version = "0.1.16-alpha"
 authors = ["IOTA Stiftung"]
 edition = "2024"
 homepage = "https://www.iota.org"
@@ -25,7 +25,10 @@ product_common = { package = "product_common", git = "https://github.com/iotaled
 secret-storage = { git = "https://github.com/iotaledger/secret-storage", tag = "v0.3.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.149"
-strum = { version = "0.27", default-features = false, features = ["derive", "std"] }
+strum = { version = "0.27", default-features = false, features = [
+  "derive",
+  "std",
+] }
 thiserror = "2.0"
 tokio = { version = "1.49.0", default-features = false, features = ["sync"] }
 

--- a/bindings/wasm/hierarchies_wasm/Cargo.toml
+++ b/bindings/wasm/hierarchies_wasm/Cargo.toml
@@ -52,9 +52,7 @@ empty_docs = "allow"
 
 [lints.rust]
 # required for current wasm_bindgen version
-unexpected_cfgs = { level = "warn", check-cfg = [
-  "cfg(wasm_bindgen_unstable_test_coverage)",
-] }
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(wasm_bindgen_unstable_test_coverage)"] }
 
 [profile.release]
 opt-level = "s"

--- a/bindings/wasm/hierarchies_wasm/Cargo.toml
+++ b/bindings/wasm/hierarchies_wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hierarchies_wasm"
-version = "0.1.15-alpha"
+version = "0.1.16-alpha"
 authors = ["IOTA Stiftung"]
 edition = "2024"
 homepage = "https://www.iota.org"
@@ -52,7 +52,9 @@ empty_docs = "allow"
 
 [lints.rust]
 # required for current wasm_bindgen version
-unexpected_cfgs = { level = "warn", check-cfg = ["cfg(wasm_bindgen_unstable_test_coverage)"] }
+unexpected_cfgs = { level = "warn", check-cfg = [
+  "cfg(wasm_bindgen_unstable_test_coverage)",
+] }
 
 [profile.release]
 opt-level = "s"

--- a/bindings/wasm/hierarchies_wasm/package-lock.json
+++ b/bindings/wasm/hierarchies_wasm/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@iota/hierarchies",
-    "version": "0.1.9",
+    "version": "0.1.10",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@iota/hierarchies",
-            "version": "0.1.9",
+            "version": "0.1.10",
             "license": "Apache-2.0",
             "dependencies": {
                 "@iota/iota-interaction-ts": "^0.13.0"

--- a/bindings/wasm/hierarchies_wasm/package.json
+++ b/bindings/wasm/hierarchies_wasm/package.json
@@ -3,7 +3,7 @@
     "author": "IOTA Foundation <info@iota.org>",
     "description": "WASM bindings for IOTA Hierarchies - To be used in JavaScript/TypeScript",
     "homepage": "https://www.iota.org",
-    "version": "0.1.9",
+    "version": "0.1.10",
     "license": "Apache-2.0",
     "repository": {
         "type": "git",

--- a/hierarchies-move/Move.history.json
+++ b/hierarchies-move/Move.history.json
@@ -5,14 +5,14 @@
     "testnet": "2304aa97"
   },
   "envs": {
+    "2304aa97": [
+      "0xbaa47178b92a43d08f79c029a385d5aff75e4e1010e12ea5105fe68f4e9ce8ef"
+    ],
     "daf90477": [
       "0x0de31a24502b692a1f1984697ad45043f5dbdf3169283aa20d08805a11b20368"
     ],
     "6364aad5": [
       "0x0f75165f01198edbc758df00d61440a46300efb639f3a5c33a7c797a8a66d371"
-    ],
-    "2304aa97": [
-      "0xbaa47178b92a43d08f79c029a385d5aff75e4e1010e12ea5105fe68f4e9ce8ef"
     ]
   }
 }

--- a/hierarchies-move/Move.history.json
+++ b/hierarchies-move/Move.history.json
@@ -5,14 +5,14 @@
     "testnet": "2304aa97"
   },
   "envs": {
-    "2304aa97": [
-      "0xbaa47178b92a43d08f79c029a385d5aff75e4e1010e12ea5105fe68f4e9ce8ef"
-    ],
     "daf90477": [
       "0x0de31a24502b692a1f1984697ad45043f5dbdf3169283aa20d08805a11b20368"
     ],
     "6364aad5": [
       "0x0f75165f01198edbc758df00d61440a46300efb639f3a5c33a7c797a8a66d371"
+    ],
+    "2304aa97": [
+      "0xbaa47178b92a43d08f79c029a385d5aff75e4e1010e12ea5105fe68f4e9ce8ef"
     ]
   }
 }


### PR DESCRIPTION
# Description of change

Bump cargo versions to `0.1.16-alpha`
Bump npmjs version for `wasm_hierarchies` to `0.1.10`