### PR TITLE
bump up the iota to v1.22.1 and product-core to 0.8.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1199,7 +1199,7 @@ dependencies = [
 [[package]]
 name = "consensus-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "fastcrypto",
  "iota-network-stack",
@@ -1875,7 +1875,7 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 [[package]]
 name = "enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "serde_yaml",
 ]
@@ -2644,7 +2644,7 @@ dependencies = [
  "chrono",
  "hierarchies",
  "hyper",
- "iota-sdk 1.22.0-alpha",
+ "iota-sdk 1.22.1",
  "product_common",
  "tokio",
 ]
@@ -3064,7 +3064,7 @@ dependencies = [
 [[package]]
 name = "iota-adapter-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3092,8 +3092,8 @@ dependencies = [
 
 [[package]]
 name = "iota-common"
-version = "1.22.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+version = "1.22.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -3113,8 +3113,8 @@ dependencies = [
 
 [[package]]
 name = "iota-config"
-version = "1.22.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+version = "1.22.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "anemo",
  "anyhow",
@@ -3177,8 +3177,8 @@ dependencies = [
 
 [[package]]
 name = "iota-enum-compat-util"
-version = "1.22.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+version = "1.22.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "serde_yaml",
 ]
@@ -3186,7 +3186,7 @@ dependencies = [
 [[package]]
 name = "iota-execution"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "iota-adapter-latest",
  "iota-move-natives-latest",
@@ -3203,8 +3203,8 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-common"
-version = "1.22.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+version = "1.22.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "iota-execution",
  "iota-protocol-config",
@@ -3214,8 +3214,8 @@ dependencies = [
 
 [[package]]
 name = "iota-http"
-version = "1.22.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+version = "1.22.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "bytes",
  "http",
@@ -3235,8 +3235,8 @@ dependencies = [
 
 [[package]]
 name = "iota-json"
-version = "1.22.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+version = "1.22.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3252,8 +3252,8 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-api"
-version = "1.22.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+version = "1.22.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -3272,8 +3272,8 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-types"
-version = "1.22.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+version = "1.22.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3307,8 +3307,8 @@ dependencies = [
 
 [[package]]
 name = "iota-keys"
-version = "1.22.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+version = "1.22.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "anyhow",
  "bip32",
@@ -3328,8 +3328,8 @@ dependencies = [
 
 [[package]]
 name = "iota-macros"
-version = "1.22.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+version = "1.22.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "futures",
  "iota-proc-macros",
@@ -3339,8 +3339,8 @@ dependencies = [
 
 [[package]]
 name = "iota-metrics"
-version = "1.22.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+version = "1.22.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -3366,7 +3366,7 @@ dependencies = [
 [[package]]
 name = "iota-move-natives-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "bcs",
  "better_any",
@@ -3389,8 +3389,8 @@ dependencies = [
 
 [[package]]
 name = "iota-names"
-version = "1.22.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+version = "1.22.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3402,8 +3402,8 @@ dependencies = [
 
 [[package]]
 name = "iota-network-stack"
-version = "1.22.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+version = "1.22.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "anemo",
  "bcs",
@@ -3432,8 +3432,8 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc"
-version = "1.22.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+version = "1.22.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -3443,8 +3443,8 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc-macros"
-version = "1.22.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+version = "1.22.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -3456,8 +3456,8 @@ dependencies = [
 
 [[package]]
 name = "iota-package-resolver"
-version = "1.22.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+version = "1.22.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "async-trait",
  "bcs",
@@ -3472,8 +3472,8 @@ dependencies = [
 
 [[package]]
 name = "iota-proc-macros"
-version = "1.22.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+version = "1.22.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "msim-macros",
  "proc-macro2",
@@ -3483,8 +3483,8 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config"
-version = "1.22.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+version = "1.22.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "clap",
  "iota-protocol-config-macros",
@@ -3498,8 +3498,8 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config-macros"
-version = "1.22.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+version = "1.22.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3539,8 +3539,8 @@ dependencies = [
 
 [[package]]
 name = "iota-sdk"
-version = "1.22.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+version = "1.22.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3575,7 +3575,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=e19c78a1bee17e0bf85fcd5b16a2f080cef26274#e19c78a1bee17e0bf85fcd5b16a2f080cef26274"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=7c1434aabb2e7b11681722edaf1a51ac52941b84#7c1434aabb2e7b11681722edaf1a51ac52941b84"
 dependencies = [
  "base64ct",
  "bcs",
@@ -3583,7 +3583,6 @@ dependencies = [
  "bnum",
  "bs58 0.5.1",
  "hex",
- "itertools 0.13.0",
  "paste",
  "roaring",
  "schemars 0.8.22",
@@ -3598,8 +3597,8 @@ dependencies = [
 
 [[package]]
 name = "iota-tls"
-version = "1.22.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+version = "1.22.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3620,8 +3619,8 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-builder"
-version = "1.22.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+version = "1.22.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3637,8 +3636,8 @@ dependencies = [
 
 [[package]]
 name = "iota-types"
-version = "1.22.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+version = "1.22.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "anemo",
  "anyhow",
@@ -3656,14 +3655,13 @@ dependencies = [
  "eyre",
  "fastcrypto",
  "fastcrypto-tbls",
- "fastcrypto-zkp",
  "futures",
  "hex",
- "im",
  "indexmap 2.12.1",
  "iota-enum-compat-util",
  "iota-macros",
  "iota-network-stack",
+ "iota-proc-macros",
  "iota-protocol-config",
  "iota-sdk-types",
  "itertools 0.13.0",
@@ -3703,7 +3701,7 @@ dependencies = [
 [[package]]
 name = "iota-verifier-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "bcs",
  "iota-types",
@@ -3718,8 +3716,8 @@ dependencies = [
 
 [[package]]
 name = "iota_interaction"
-version = "0.8.16"
-source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.16#1d3480d6536cdf9152e754a4d1c7474438785f4a"
+version = "0.8.17"
+source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.17#7a67b7ff914aacb63522e95d74c0ac8733d28f33"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3733,7 +3731,7 @@ dependencies = [
  "hex",
  "hyper",
  "indexmap 2.12.1",
- "iota-sdk 1.22.0-alpha",
+ "iota-sdk 1.22.1",
  "iota-sdk-types",
  "itertools 0.13.0",
  "jsonpath-rust",
@@ -3761,8 +3759,8 @@ dependencies = [
 
 [[package]]
 name = "iota_interaction_rust"
-version = "0.8.16"
-source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.16#1d3480d6536cdf9152e754a4d1c7474438785f4a"
+version = "0.8.17"
+source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.17#7a67b7ff914aacb63522e95d74c0ac8733d28f33"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3774,8 +3772,8 @@ dependencies = [
 
 [[package]]
 name = "iota_interaction_ts"
-version = "0.8.16"
-source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.16#1d3480d6536cdf9152e754a4d1c7474438785f4a"
+version = "0.8.17"
+source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.17#7a67b7ff914aacb63522e95d74c0ac8733d28f33"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4411,7 +4409,7 @@ dependencies = [
 [[package]]
 name = "move-abstract-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "move-binary-format",
  "move-bytecode-verifier-meter",
@@ -4420,12 +4418,12 @@ dependencies = [
 [[package]]
 name = "move-abstract-stack"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "anyhow",
  "enum-compat-util",
@@ -4440,12 +4438,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4461,7 +4459,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "anyhow",
  "indexmap 2.12.1",
@@ -4475,7 +4473,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -4491,7 +4489,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-meter"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -4501,7 +4499,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4521,7 +4519,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4556,7 +4554,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4580,7 +4578,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4601,7 +4599,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4622,7 +4620,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -4640,7 +4638,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "anyhow",
  "hex",
@@ -4653,7 +4651,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -4666,7 +4664,7 @@ dependencies = [
 [[package]]
 name = "move-proc-macros"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "quote",
  "syn 2.0.111",
@@ -4675,7 +4673,7 @@ dependencies = [
 [[package]]
 name = "move-regex-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -4685,7 +4683,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives"
 version = "0.1.1"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -4700,7 +4698,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "once_cell",
  "phf",
@@ -4710,7 +4708,7 @@ dependencies = [
 [[package]]
 name = "move-trace-format"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -4721,7 +4719,7 @@ dependencies = [
 [[package]]
 name = "move-vm-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "move-binary-format",
  "once_cell",
@@ -4730,7 +4728,7 @@ dependencies = [
 [[package]]
 name = "move-vm-profiler"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "move-vm-config",
  "once_cell",
@@ -4740,7 +4738,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "better_any",
  "fail",
@@ -4760,7 +4758,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -4774,7 +4772,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -5785,8 +5783,8 @@ dependencies = [
 
 [[package]]
 name = "product_common"
-version = "0.8.16"
-source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.16#1d3480d6536cdf9152e754a4d1c7474438785f4a"
+version = "0.8.17"
+source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.17#7a67b7ff914aacb63522e95d74c0ac8733d28f33"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5795,7 +5793,7 @@ dependencies = [
  "fastcrypto",
  "hyper",
  "iota-keys",
- "iota-sdk 1.22.0-alpha",
+ "iota-sdk 1.22.1",
  "iota-sdk-types",
  "iota_interaction",
  "iota_interaction_rust",
@@ -5831,8 +5829,8 @@ dependencies = [
 
 [[package]]
 name = "prometheus-closure-metric"
-version = "1.22.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+version = "1.22.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -7187,7 +7185,7 @@ dependencies = [
 [[package]]
 name = "starfish-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "blake3",
  "fastcrypto",
@@ -7959,8 +7957,8 @@ dependencies = [
 
 [[package]]
 name = "typed-store-error"
-version = "1.22.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=96196f0da231883ec69cda04892c600ef6afa982#96196f0da231883ec69cda04892c600ef6afa982"
+version = "1.22.1"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
 dependencies = [
  "serde",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,11 @@ async-trait = "0.1"
 bcs = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 hyper = "1.8"
-iota-sdk = { package = "iota-sdk", git = "https://github.com/iotaledger/iota.git", rev = "96196f0da231883ec69cda04892c600ef6afa982" }
-iota_interaction = { package = "iota_interaction", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.16", default-features = false }
-iota_interaction_rust = { package = "iota_interaction_rust", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.16", default-features = false }
-iota_interaction_ts = { package = "iota_interaction_ts", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.16", default-features = false }
-product_common = { package = "product_common", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.16", default-features = false }
+iota-sdk = { package = "iota-sdk", git = "https://github.com/iotaledger/iota.git", tag = "v1.22.1" }
+iota_interaction = { package = "iota_interaction", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.17", default-features = false }
+iota_interaction_rust = { package = "iota_interaction_rust", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.17", default-features = false }
+iota_interaction_ts = { package = "iota_interaction_ts", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.17", default-features = false }
+product_common = { package = "product_common", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.17", default-features = false }
 secret-storage = { git = "https://github.com/iotaledger/secret-storage", tag = "v0.3.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.149"

--- a/bindings/wasm/hierarchies_wasm/Cargo.toml
+++ b/bindings/wasm/hierarchies_wasm/Cargo.toml
@@ -19,8 +19,8 @@ crate-type = ["cdylib", "rlib"]
 anyhow = "1.0"
 console_error_panic_hook = "0.1"
 hyper = "1.8"
-iota_interaction = { package = "iota_interaction", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.16", default-features = false }
-iota_interaction_ts = { package = "iota_interaction_ts", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.16" }
+iota_interaction = { package = "iota_interaction", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.17", default-features = false }
+iota_interaction_ts = { package = "iota_interaction_ts", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.17" }
 js-sys = { version = "=0.3.85" }
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6"
@@ -35,7 +35,7 @@ features = ["default-http-client", "gas-station"]
 [dependencies.product_common]
 package = "product_common"
 git = "https://github.com/iotaledger/product-core.git"
-tag = "v0.8.16"
+tag = "v0.8.17"
 features = [
   "default-http-client",
   "binding-utils",


### PR DESCRIPTION
# Description of change

Following dependencies have been changed:
- [ ] tokio version update to: -
- [ ] fastcrypto version update to rev = "-"
- [ ] notarization_wasm: new peerDep. version for @iota/iota-sdk:
- [ ] notarization_wasm: new dependency version for @iota/iota-interaction-ts: _
- [x] pin all product-core.git dependencies to `tag = "v0.8.17"`
- [x] pin all iota.git dependencies to `tag = "v1.22.1"`

## Links to any relevant issues
https://github.com/iotaledger/product-core/issues/67