### PR TITLE
feat: bump up the iota to v1.23  - migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,22 +4,13 @@ version = 4
 
 [[package]]
 name = "addchain"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2e69442aa5628ea6951fa33e24efe8313f4321a91bd729fc2f75bdfc858570"
+checksum = "2e33f6a175ec6a9e0aca777567f9ff7c3deefc255660df887e7fa3585e9801d8"
 dependencies = [
  "num-bigint 0.3.3",
  "num-integer",
  "num-traits",
-]
-
-[[package]]
-name = "addr2line"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
-dependencies = [
- "gimli",
 ]
 
 [[package]]
@@ -40,7 +31,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -52,7 +43,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -129,7 +120,7 @@ dependencies = [
  "pkcs8 0.10.2",
  "quinn",
  "quinn-proto",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rcgen",
  "ring",
  "rustls",
@@ -166,9 +157,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -181,15 +172,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -216,29 +207,17 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
-dependencies = [
- "backtrace",
-]
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "ar_archive_writer"
-version = "0.2.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c269894b6fe5e9d7ada0cf69b5bf847ff35bc25fc271f08e1d080fce80339a"
+checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
 dependencies = [
- "object 0.32.2",
-]
-
-[[package]]
-name = "arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
-dependencies = [
- "derive_arbitrary",
+ "object",
 ]
 
 [[package]]
@@ -432,7 +411,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -449,9 +428,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "asn1-rs"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
 dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
@@ -459,7 +438,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -471,7 +450,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -483,7 +462,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -505,7 +484,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -516,7 +495,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -533,15 +512,15 @@ checksum = "7460f7dd8e100147b82a63afca1a20eb6c231ee36b90ba7272e14951cb58af59"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "axum"
-version = "0.8.7"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b098575ebe77cb6d14fc7f32749631a6e44edbef6b796f89b020e99ba20d425"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "axum-macros",
@@ -568,16 +547,16 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
 ]
 
 [[package]]
 name = "axum-core"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59446ce19cd142f8833f856eb31f3eb097812d1479ab224f54d72428ca21ea22"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
@@ -593,13 +572,13 @@ dependencies = [
 
 [[package]]
 name = "axum-macros"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
+checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -622,21 +601,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
-]
-
-[[package]]
-name = "backtrace"
-version = "0.3.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object 0.37.3",
- "rustc-demangle",
- "windows-link",
 ]
 
 [[package]]
@@ -681,9 +645,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.8.1"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e050f626429857a27ddccb31e0aca21356bfa709c04041aefddac081a8f068a"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bcs"
@@ -796,9 +760,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bitmaps"
@@ -844,37 +808,38 @@ dependencies = [
 
 [[package]]
 name = "blake2b_simd"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06e903a20b159e944f91ec8499fe1e55651480c541ea0a584f5d967c49ad9d99"
+checksum = "b79834656f71332577234b50bfc009996f7449e0c056884e6a02492ded0ca2f3"
 dependencies = [
  "arrayref",
  "arrayvec",
- "constant_time_eq 0.3.1",
+ "constant_time_eq 0.4.2",
 ]
 
 [[package]]
 name = "blake2s_simd"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90f7deecfac93095eb874a40febd69427776e24e1bd7f87f33ac62d6f0174df"
+checksum = "ee29928bad1e3f94c9d1528da29e07a1d3d04817ae8332de1e8b846c8439f4b3"
 dependencies = [
  "arrayref",
  "arrayvec",
- "constant_time_eq 0.3.1",
+ "constant_time_eq 0.4.2",
 ]
 
 [[package]]
 name = "blake3"
-version = "1.8.2"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
- "constant_time_eq 0.3.1",
+ "constant_time_eq 0.4.2",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -893,6 +858,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -956,9 +930,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byte-slice-cast"
@@ -974,9 +948,9 @@ checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
-version = "1.24.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"
@@ -986,11 +960,20 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bytestring"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86566c496f2f47d9b8147a4c8b02ffdb69c919fe0c2b2e7195d22cbba0e635c9"
+dependencies = [
+ "bytes",
 ]
 
 [[package]]
@@ -1004,9 +987,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.49"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90583009037521a116abf44494efecd645ba48b6622457080f080b85544e2215"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1040,7 +1023,18 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1050,7 +1044,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -1058,9 +1052,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.42"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1103,16 +1097,16 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
  "zeroize",
 ]
 
 [[package]]
 name = "clap"
-version = "4.5.53"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1120,9 +1114,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.53"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1133,21 +1127,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.6"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codespan"
@@ -1172,9 +1166,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "colored"
@@ -1197,28 +1191,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "consensus-config"
-version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
-dependencies = [
- "fastcrypto",
- "iota-network-stack",
- "iota-sdk-types",
- "rand 0.8.5",
- "serde",
- "tracing",
-]
-
-[[package]]
 name = "console"
-version = "0.15.11"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1228,6 +1208,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "const-str"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1235,11 +1221,12 @@ checksum = "2f421161cb492475f1661ddc9815a745a1c894592070661180fdec3d4872e9c3"
 
 [[package]]
 name = "const_format"
-version = "0.2.35"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
 dependencies = [
  "const_format_proc_macros",
+ "konst",
 ]
 
 [[package]]
@@ -1261,15 +1248,24 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "constant_time_eq"
-version = "0.3.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation"
@@ -1288,15 +1284,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "coset"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1311,6 +1298,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1379,6 +1375,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "csv"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1415,7 +1420,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
@@ -1432,7 +1437,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1460,12 +1465,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -1484,16 +1489,15 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1509,20 +1513,20 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core 0.23.0",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "dary_heap"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06d2e3287df1c007e74221c49ca10a95d557349e54b3a75dc2fb14712c751f04"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
 
 [[package]]
 name = "dashmap"
@@ -1539,15 +1543,15 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.9.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "data-encoding-macro"
-version = "0.1.18"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47ce6c96ea0102f01122a185683611bd5ac8d99e62bc59dd12e6bda344ee673d"
+checksum = "3259c913752a86488b501ed8680446a5ed2d5aeac6e596cb23ba3800768ea32c"
 dependencies = [
  "data-encoding",
  "data-encoding-macro-internal",
@@ -1555,12 +1559,12 @@ dependencies = [
 
 [[package]]
 name = "data-encoding-macro-internal"
-version = "0.1.16"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
+checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1569,7 +1573,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468 0.6.0",
  "zeroize",
 ]
@@ -1580,7 +1584,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468 0.7.0",
  "zeroize",
 ]
@@ -1601,9 +1605,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
@@ -1632,27 +1636,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.111",
-]
-
-[[package]]
 name = "derive_more"
 version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
- "convert_case",
+ "convert_case 0.4.0",
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1661,7 +1654,16 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
 dependencies = [
- "derive_more-impl",
+ "derive_more-impl 1.0.0",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl 2.1.1",
 ]
 
 [[package]]
@@ -1672,7 +1674,21 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
+ "unicode-xid",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case 0.10.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
  "unicode-xid",
 ]
 
@@ -1692,9 +1708,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid",
- "crypto-common",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1761,13 +1788,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1826,9 +1853,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-zebra"
-version = "4.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0017d969298eec91e3db7a2985a8cab4df6341d86e6f3a6f5878b13fb7846bc9"
+checksum = "775765289f7c6336c18d3d66127527820dd45ffd9eb3b6b8ee4708590e6c20f5"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
@@ -1841,9 +1868,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elliptic-curve"
@@ -1875,7 +1902,7 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 [[package]]
 name = "enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "serde_yaml",
 ]
@@ -1889,7 +1916,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1919,9 +1946,9 @@ dependencies = [
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "eyre"
@@ -1979,7 +2006,7 @@ dependencies = [
  "num-bigint 0.4.6",
  "once_cell",
  "p256",
- "rand 0.8.5",
+ "rand 0.8.6",
  "readonly",
  "rfc6979",
  "rsa",
@@ -1989,7 +2016,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha2 0.10.9",
- "sha3",
+ "sha3 0.10.9",
  "signature 2.2.0",
  "static_assertions",
  "thiserror 1.0.69",
@@ -2017,9 +2044,9 @@ dependencies = [
  "fastcrypto",
  "hex",
  "itertools 0.10.5",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
- "sha3",
+ "sha3 0.10.9",
  "tap",
  "tracing",
  "typenum",
@@ -2038,7 +2065,7 @@ dependencies = [
  "num-integer",
  "num-prime",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
  "serde",
 ]
@@ -2067,7 +2094,7 @@ dependencies = [
  "num-bigint 0.4.6",
  "once_cell",
  "regex",
- "reqwest 0.12.26",
+ "reqwest 0.12.28",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -2076,9 +2103,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ff"
@@ -2116,21 +2143,19 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
-version = "0.2.26"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
- "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.5"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixed-hash"
@@ -2139,7 +2164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
 dependencies = [
  "byteorder",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustc-hex",
  "static_assertions",
 ]
@@ -2151,7 +2176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustc-hex",
  "static_assertions",
 ]
@@ -2164,13 +2189,12 @@ checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "flate2"
-version = "1.1.5"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
- "crc32fast",
- "libz-rs-sys",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -2224,9 +2248,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2239,9 +2263,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2249,15 +2273,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2266,32 +2290,32 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
@@ -2305,9 +2329,9 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2317,7 +2341,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -2346,9 +2369,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2366,9 +2389,23 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -2380,7 +2417,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2392,12 +2429,6 @@ dependencies = [
  "opaque-debug",
  "polyval",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glob"
@@ -2478,7 +2509,7 @@ dependencies = [
  "parking_lot 0.12.5",
  "portable-atomic",
  "quanta",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "spinning_top",
 ]
@@ -2490,7 +2521,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_core 0.6.4",
  "rand_xorshift",
  "subtle",
@@ -2498,9 +2529,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.12"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2508,7 +2539,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.12.1",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2574,6 +2605,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "hdrhistogram"
 version = "7.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2632,7 +2669,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum 0.27.2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -2644,7 +2681,7 @@ dependencies = [
  "chrono",
  "hierarchies",
  "hyper",
- "iota-sdk 1.22.1",
+ "iota-sdk 1.23.2",
  "product_common",
  "tokio",
 ]
@@ -2675,9 +2712,9 @@ checksum = "77e806677ce663d0a199541030c816847b36e8dc095f70dae4a4f4ad63da5383"
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -2725,10 +2762,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
-name = "hyper"
-version = "1.8.1"
+name = "hybrid-array"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb92f162bf56536459fc83c79b974bb12837acfed43d6bc370a7916d0ae15ecc"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2741,7 +2787,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -2749,9 +2794,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
@@ -2759,7 +2804,6 @@ dependencies = [
  "log",
  "rustls",
  "rustls-native-certs",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -2796,7 +2840,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -2804,9 +2848,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.64"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -2828,12 +2872,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -2841,9 +2886,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2854,9 +2899,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -2868,15 +2913,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -2888,15 +2933,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -2906,6 +2951,12 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -2926,9 +2977,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -2992,7 +3043,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3014,12 +3065,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.12.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -3042,14 +3093,15 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.44.3"
+version = "1.47.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5c943d4415edd8153251b6f197de5eb1640e56d84e8d9159bea190421c73698"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
 dependencies = [
  "console",
  "once_cell",
  "serde",
  "similar",
+ "tempfile",
 ]
 
 [[package]]
@@ -3064,7 +3116,7 @@ dependencies = [
 [[package]]
 name = "iota-adapter-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3092,8 +3144,8 @@ dependencies = [
 
 [[package]]
 name = "iota-common"
-version = "1.22.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+version = "1.23.2"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -3103,8 +3155,8 @@ dependencies = [
  "iota-types",
  "once_cell",
  "parking_lot 0.12.5",
- "rand 0.8.5",
- "reqwest 0.12.26",
+ "rand 0.8.6",
+ "reqwest 0.12.28",
  "snap",
  "tempfile",
  "tokio",
@@ -3113,14 +3165,13 @@ dependencies = [
 
 [[package]]
 name = "iota-config"
-version = "1.22.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+version = "1.23.2"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "anemo",
  "anyhow",
  "bcs",
  "clap",
- "consensus-config",
  "csv",
  "dirs 5.0.1",
  "fastcrypto",
@@ -3132,8 +3183,8 @@ dependencies = [
  "object_store",
  "once_cell",
  "prometheus",
- "rand 0.8.5",
- "reqwest 0.12.26",
+ "rand 0.8.6",
+ "reqwest 0.12.28",
  "serde",
  "serde_yaml",
  "starfish-config",
@@ -3158,14 +3209,14 @@ dependencies = [
  "digest 0.10.7",
  "ed25519-zebra",
  "generic-array",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "hkdf",
  "hmac",
  "iterator-sorted 0.1.0",
  "k256",
  "num-traits",
  "pbkdf2 0.12.2",
- "rand 0.8.5",
+ "rand 0.8.6",
  "scrypt",
  "serde",
  "sha2 0.10.9",
@@ -3177,8 +3228,8 @@ dependencies = [
 
 [[package]]
 name = "iota-enum-compat-util"
-version = "1.22.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+version = "1.23.2"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "serde_yaml",
 ]
@@ -3186,7 +3237,7 @@ dependencies = [
 [[package]]
 name = "iota-execution"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "iota-adapter-latest",
  "iota-move-natives-latest",
@@ -3203,8 +3254,8 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-common"
-version = "1.22.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+version = "1.23.2"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "iota-execution",
  "iota-protocol-config",
@@ -3214,8 +3265,8 @@ dependencies = [
 
 [[package]]
 name = "iota-http"
-version = "1.22.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+version = "1.23.2"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "bytes",
  "http",
@@ -3235,8 +3286,8 @@ dependencies = [
 
 [[package]]
 name = "iota-json"
-version = "1.22.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+version = "1.23.2"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3252,8 +3303,8 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-api"
-version = "1.22.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+version = "1.23.2"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -3272,8 +3323,8 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-types"
-version = "1.22.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+version = "1.23.2"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3288,6 +3339,7 @@ dependencies = [
  "iota-names",
  "iota-package-resolver",
  "iota-protocol-config",
+ "iota-sdk-types",
  "iota-types",
  "itertools 0.13.0",
  "json_to_table",
@@ -3302,20 +3354,21 @@ dependencies = [
  "serde_with",
  "strum 0.27.2",
  "tabled",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
 [[package]]
 name = "iota-keys"
-version = "1.22.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+version = "1.23.2"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "anyhow",
  "bip32",
  "fastcrypto",
  "iota-sdk-types",
  "iota-types",
- "rand 0.8.5",
+ "rand 0.8.6",
  "regex",
  "serde",
  "serde_json",
@@ -3328,8 +3381,8 @@ dependencies = [
 
 [[package]]
 name = "iota-macros"
-version = "1.22.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+version = "1.23.2"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "futures",
  "iota-proc-macros",
@@ -3339,8 +3392,8 @@ dependencies = [
 
 [[package]]
 name = "iota-metrics"
-version = "1.22.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+version = "1.23.2"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -3366,14 +3419,14 @@ dependencies = [
 [[package]]
 name = "iota-move-natives-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "bcs",
  "better_any",
  "fastcrypto",
  "fastcrypto-vdf",
  "fastcrypto-zkp",
- "indexmap 2.12.1",
+ "indexmap 2.14.0",
  "iota-protocol-config",
  "iota-types",
  "move-binary-format",
@@ -3381,7 +3434,7 @@ dependencies = [
  "move-stdlib-natives",
  "move-vm-runtime",
  "move-vm-types",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "smallvec",
  "tracing",
@@ -3389,8 +3442,8 @@ dependencies = [
 
 [[package]]
 name = "iota-names"
-version = "1.22.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+version = "1.23.2"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3402,8 +3455,8 @@ dependencies = [
 
 [[package]]
 name = "iota-network-stack"
-version = "1.22.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+version = "1.23.2"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "anemo",
  "bcs",
@@ -3432,8 +3485,8 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc"
-version = "1.22.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+version = "1.23.2"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -3443,8 +3496,8 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc-macros"
-version = "1.22.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+version = "1.23.2"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -3456,8 +3509,8 @@ dependencies = [
 
 [[package]]
 name = "iota-package-resolver"
-version = "1.22.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+version = "1.23.2"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "async-trait",
  "bcs",
@@ -3467,24 +3520,23 @@ dependencies = [
  "move-command-line-common",
  "move-core-types",
  "thiserror 1.0.69",
- "tokio",
 ]
 
 [[package]]
 name = "iota-proc-macros"
-version = "1.22.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+version = "1.23.2"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "msim-macros",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "iota-protocol-config"
-version = "1.22.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+version = "1.23.2"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "clap",
  "iota-protocol-config-macros",
@@ -3498,8 +3550,8 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config-macros"
-version = "1.22.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+version = "1.23.2"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3513,7 +3565,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1dfb0cae5c5bad8186576ca00b8be675257431eda028dcea01cb3b9f276037e"
 dependencies = [
  "bech32",
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "bytemuck",
  "derive_more 0.99.20",
  "getset",
@@ -3529,7 +3581,7 @@ dependencies = [
  "packable",
  "prefix-hex",
  "primitive-types 0.12.2",
- "rand 0.8.5",
+ "rand 0.8.6",
  "regex",
  "serde",
  "serde_json",
@@ -3539,8 +3591,8 @@ dependencies = [
 
 [[package]]
 name = "iota-sdk"
-version = "1.22.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+version = "1.23.2"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3562,7 +3614,7 @@ dependencies = [
  "iota-types",
  "jsonrpsee",
  "move-core-types",
- "reqwest 0.12.26",
+ "reqwest 0.12.28",
  "rustls",
  "serde",
  "serde_json",
@@ -3575,30 +3627,33 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=7c1434aabb2e7b11681722edaf1a51ac52941b84#7c1434aabb2e7b11681722edaf1a51ac52941b84"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=c37fbcc9ad56c92f23582dcdb8203e3594088639#c37fbcc9ad56c92f23582dcdb8203e3594088639"
 dependencies = [
  "base64ct",
  "bcs",
  "blake2",
  "bnum",
  "bs58 0.5.1",
+ "bytestring",
+ "derive_more 2.1.1",
+ "filetime",
  "hex",
  "paste",
+ "rand_core 0.6.4",
  "roaring",
- "schemars 0.8.22",
  "serde",
  "serde_json",
  "serde_repr",
  "serde_with",
  "strum 0.27.2",
- "thiserror 2.0.17",
- "winnow 0.7.14",
+ "thiserror 2.0.18",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "iota-tls"
-version = "1.22.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+version = "1.23.2"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3608,7 +3663,7 @@ dependencies = [
  "fastcrypto",
  "pkcs8 0.10.2",
  "rcgen",
- "reqwest 0.12.26",
+ "reqwest 0.12.28",
  "rustls",
  "rustls-webpki",
  "tokio",
@@ -3619,8 +3674,8 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-builder"
-version = "1.22.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+version = "1.23.2"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3636,8 +3691,8 @@ dependencies = [
 
 [[package]]
 name = "iota-types"
-version = "1.22.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+version = "1.23.2"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "anemo",
  "anyhow",
@@ -3648,7 +3703,6 @@ dependencies = [
  "better_any",
  "bincode",
  "byteorder",
- "consensus-config",
  "derive_more 1.0.0",
  "either",
  "enum_dispatch",
@@ -3657,8 +3711,7 @@ dependencies = [
  "fastcrypto-tbls",
  "futures",
  "hex",
- "indexmap 2.12.1",
- "iota-enum-compat-util",
+ "indexmap 2.14.0",
  "iota-macros",
  "iota-network-stack",
  "iota-proc-macros",
@@ -3679,9 +3732,8 @@ dependencies = [
  "passkey-types",
  "prometheus",
  "prost-types",
- "rand 0.8.5",
+ "rand 0.8.6",
  "roaring",
- "schemars 0.8.22",
  "serde",
  "serde-name",
  "serde_json",
@@ -3701,7 +3753,7 @@ dependencies = [
 [[package]]
 name = "iota-verifier-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "bcs",
  "iota-types",
@@ -3717,7 +3769,7 @@ dependencies = [
 [[package]]
 name = "iota_interaction"
 version = "0.8.17"
-source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.17#7a67b7ff914aacb63522e95d74c0ac8733d28f33"
+source = "git+https://github.com/iotaledger/product-core.git?branch=feat%2Fiota-v1-23-rc-upstream-merge#b6d5bd7cacf2dde69c9bee1104920f8e0304a236"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3730,8 +3782,8 @@ dependencies = [
  "fastcrypto-zkp",
  "hex",
  "hyper",
- "indexmap 2.12.1",
- "iota-sdk 1.22.1",
+ "indexmap 2.14.0",
+ "iota-sdk 1.23.2",
  "iota-sdk-types",
  "itertools 0.13.0",
  "jsonpath-rust",
@@ -3742,11 +3794,12 @@ dependencies = [
  "move-core-types",
  "nonempty",
  "primitive-types 0.12.2",
- "rand 0.8.5",
+ "rand 0.8.6",
  "ref-cast",
  "schemars 0.8.22",
  "secret-storage",
  "serde",
+ "serde-name",
  "serde_json",
  "serde_repr",
  "serde_with",
@@ -3760,11 +3813,12 @@ dependencies = [
 [[package]]
 name = "iota_interaction_rust"
 version = "0.8.17"
-source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.17#7a67b7ff914aacb63522e95d74c0ac8733d28f33"
+source = "git+https://github.com/iotaledger/product-core.git?branch=feat%2Fiota-v1-23-rc-upstream-merge#b6d5bd7cacf2dde69c9bee1104920f8e0304a236"
 dependencies = [
  "anyhow",
  "async-trait",
  "bcs",
+ "iota-sdk-types",
  "iota_interaction",
  "secret-storage",
  "serde",
@@ -3773,7 +3827,7 @@ dependencies = [
 [[package]]
 name = "iota_interaction_ts"
 version = "0.8.17"
-source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.17#7a67b7ff914aacb63522e95d74c0ac8733d28f33"
+source = "git+https://github.com/iotaledger/product-core.git?branch=feat%2Fiota-v1-23-rc-upstream-merge#b6d5bd7cacf2dde69c9bee1104920f8e0304a236"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3782,10 +3836,11 @@ dependencies = [
  "eyre",
  "fastcrypto",
  "futures",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "getrandom 0.3.4",
  "hyper",
  "iota-sdk 1.1.5",
+ "iota-sdk-types",
  "iota_interaction",
  "js-sys",
  "secret-storage",
@@ -3819,19 +3874,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
-
-[[package]]
-name = "iri-string"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f867b9d1d896b67beb18518eda36fdb77a32ea590de864f1325b294a6d14397"
-dependencies = [
- "memchr",
- "serde",
-]
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -3889,9 +3934,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
@@ -3902,7 +3947,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -3911,9 +3956,31 @@ dependencies = [
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "jobserver"
@@ -3961,9 +4028,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.24.10"
+version = "0.24.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e281ae70cc3b98dac15fced3366a880949e65fc66e345ce857a5682d152f3e62"
+checksum = "72c4b1f204b655b36b24dc4939af20366c649431d4711863bbbae5c495f3eeb4"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
@@ -3979,9 +4046,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-client-transport"
-version = "0.24.10"
+version = "0.24.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4280b709ac3bb5e16cf3bad5056a0ec8df55fa89edfe996361219aadc2c7ea"
+checksum = "b3e1420b1792cff778e2a1ebaa44115f156ee62a94dd106eaa51163f037d2023"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
@@ -4004,9 +4071,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.24.10"
+version = "0.24.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "348ee569eaed52926b5e740aae20863762b16596476e943c9e415a6479021622"
+checksum = "f49bfa9334963e1c85866b39dff3ffcc81f1c286eb23334267c5cb97677543a4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4018,8 +4085,8 @@ dependencies = [
  "jsonrpsee-types",
  "parking_lot 0.12.5",
  "pin-project",
- "rand 0.8.5",
- "rustc-hash 2.1.1",
+ "rand 0.8.6",
+ "rustc-hash 2.1.2",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -4031,9 +4098,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-http-client"
-version = "0.24.10"
+version = "0.24.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50c389d6e6a52eb7c3548a6600c90cf74d9b71cb5912209833f00a5479e9a01"
+checksum = "c215647e43482d478a6c21f021a013b50d64cf63431c1176eda9ef925dc54ec8"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4056,22 +4123,22 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-proc-macros"
-version = "0.24.10"
+version = "0.24.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7398cddf5013cca4702862a2692b66c48a3bd6cf6ec681a47453c93d63cf8de5"
+checksum = "f5248249c016692f1465a753057ae8347681995dd490c2cb65c48b14b46215a8"
 dependencies = [
  "heck 0.5.0",
- "proc-macro-crate 3.4.0",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "jsonrpsee-server"
-version = "0.24.10"
+version = "0.24.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21429bcdda37dcf2d43b68621b994adede0e28061f816b038b0f18c70c143d51"
+checksum = "c625c78b8d545478370b6e7a2a191b0d921f831a9eef38dc1e7efb57e7a5472f"
 dependencies = [
  "futures-util",
  "http",
@@ -4096,9 +4163,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.24.10"
+version = "0.24.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0f05e0028e55b15dbd2107163b3c744cd3bb4474f193f95d9708acbf5677e44"
+checksum = "41d86fc943f81dab0ecdd6c0240b6e0f55ad57a2ea9ad8ad7efe8456fb9cc7a4"
 dependencies = [
  "http",
  "serde",
@@ -4108,9 +4175,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-wasm-client"
-version = "0.24.10"
+version = "0.24.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9d745e4f543fc10fc0e2b11aa1f3be506b1e475d412167e7191a65ecd239f1c"
+checksum = "735df2088674c87f7fecdf51c80878a7aa19a8116b32d703b000f5b1a7acf95a"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
@@ -4119,9 +4186,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-ws-client"
-version = "0.24.10"
+version = "0.24.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78fc744f17e7926d57f478cf9ca6e1ee5d8332bf0514860b1a3cdf1742e614cc"
+checksum = "9df5bd5c38c0906a6e8b3a38c8c22cc8525fda25fd1a03a3fe010686aea66b70"
 dependencies = [
  "http",
  "jsonrpsee-client-transport",
@@ -4146,12 +4213,37 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
+
+[[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "lazy_static"
@@ -4164,76 +4256,80 @@ dependencies = [
 
 [[package]]
 name = "leb128"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
+checksum = "6cc46bac87ef8093eed6f272babb833b6443374399985ac8ed28471ee0918545"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.178"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libflate"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3248b8d211bd23a104a42d81b4fa8bb8ac4a3b75e7a43d85d2c9ccb6179cd74"
+checksum = "cd96e993e5f3368b0cb8497dae6c860c22af8ff18388c61c6c0b86c58d86b5df"
 dependencies = [
  "adler32",
- "core2",
  "crc32fast",
  "dary_heap",
  "libflate_lz77",
+ "no_std_io2",
 ]
 
 [[package]]
 name = "libflate_lz77"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a599cb10a9cd92b1300debcef28da8f70b935ec937f44fcd1b70a7c986a11c5c"
+checksum = "ff7a10e427698aef6eef269482776debfef63384d30f13aad39a1a95e0e098fd"
 dependencies = [
- "core2",
  "hashbrown 0.16.1",
+ "no_std_io2",
  "rle-decode-fast",
 ]
 
 [[package]]
 name = "libm"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libp2p-identity"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c7892c221730ba55f7196e98b0b8ba5e04b4155651736036628e9f73ed6fc3"
+checksum = "9525f3831544f7ae497bde79adf114ef127b0fbbb97edbbf692a80408636421c"
 dependencies = [
  "bs58 0.5.1",
  "hkdf",
  "multihash",
  "sha2 0.10.9",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "libredox"
-version = "0.1.11"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df15f6eac291ed1cf25865b1ee60399f57e7c227e7f51bdbd4c5270396a9ed50"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
- "bitflags 2.10.0",
  "libc",
- "redox_syscall 0.6.0",
 ]
 
 [[package]]
 name = "libsodium-sys-stable"
-version = "1.22.6"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186bf786351b393a91025e9fc2f1058b8b8e1c7ecfde142ed829c209ab95daff"
+checksum = "72b04bf6da2c98b727af37ab62cb505f4d751b975b034a9b9ad491d333b0564e"
 dependencies = [
  "cc",
  "libc",
@@ -4247,15 +4343,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libz-rs-sys"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15413ef615ad868d4d65dce091cb233b229419c7c0c4bcaa746c0901c49ff39c"
-dependencies = [
- "zlib-rs",
-]
-
-[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4263,15 +4350,15 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -4284,9 +4371,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 dependencies = [
  "serde_core",
 ]
@@ -4321,13 +4408,13 @@ dependencies = [
 
 [[package]]
 name = "match-lookup"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1265724d8cb29dbbc2b0f06fffb8bf1a8c0cf73a78eede9ba73a4a66c52a981e"
+checksum = "757aee279b8bdbb9f9e676796fd459e4207a1f986e87886700abf589f5abf771"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4354,9 +4441,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memoffset"
@@ -4381,9 +4468,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "minisign-verify"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e856fdd13623a2f5f2f54676a4ee49502a96a80ef4a62bcedd23d52427c44d43"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -4397,9 +4484,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
@@ -4409,7 +4496,7 @@ dependencies = [
 [[package]]
 name = "move-abstract-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "move-binary-format",
  "move-bytecode-verifier-meter",
@@ -4418,16 +4505,16 @@ dependencies = [
 [[package]]
 name = "move-abstract-stack"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "anyhow",
  "enum-compat-util",
- "indexmap 2.12.1",
+ "indexmap 2.14.0",
  "move-core-types",
  "move-proc-macros",
  "ref-cast",
@@ -4438,12 +4525,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4459,10 +4546,10 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "anyhow",
- "indexmap 2.12.1",
+ "indexmap 2.14.0",
  "move-binary-format",
  "move-core-types",
  "petgraph",
@@ -4473,7 +4560,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -4489,7 +4576,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-meter"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -4499,7 +4586,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4519,7 +4606,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4554,7 +4641,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4566,7 +4653,7 @@ dependencies = [
  "num",
  "once_cell",
  "primitive-types 0.10.1",
- "rand 0.8.5",
+ "rand 0.8.6",
  "ref-cast",
  "serde",
  "serde_bytes",
@@ -4578,14 +4665,14 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "anyhow",
  "bcs",
  "clap",
  "codespan",
  "colored",
- "indexmap 2.12.1",
+ "indexmap 2.14.0",
  "move-abstract-interpreter",
  "move-binary-format",
  "move-bytecode-source-map",
@@ -4599,7 +4686,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4620,7 +4707,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -4638,7 +4725,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "anyhow",
  "hex",
@@ -4651,7 +4738,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -4664,16 +4751,16 @@ dependencies = [
 [[package]]
 name = "move-proc-macros"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "move-regex-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -4683,7 +4770,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives"
 version = "0.1.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -4691,14 +4778,14 @@ dependencies = [
  "move-vm-runtime",
  "move-vm-types",
  "sha2 0.10.9",
- "sha3",
+ "sha3 0.11.0",
  "smallvec",
 ]
 
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "once_cell",
  "phf",
@@ -4708,7 +4795,7 @@ dependencies = [
 [[package]]
 name = "move-trace-format"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -4719,7 +4806,7 @@ dependencies = [
 [[package]]
 name = "move-vm-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "move-binary-format",
  "once_cell",
@@ -4728,7 +4815,7 @@ dependencies = [
 [[package]]
 name = "move-vm-profiler"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "move-vm-config",
  "once_cell",
@@ -4738,7 +4825,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "better_any",
  "fail",
@@ -4758,7 +4845,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -4772,7 +4859,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -4785,7 +4872,7 @@ dependencies = [
 [[package]]
 name = "msim-macros"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota-sim.git?branch=tokio-1.49.0#b8604de3e34a1b2a47601f3003ab98e5d7889c0e"
+source = "git+https://github.com/iotaledger/iota-sim.git?branch=tokio-1.52.2#2d1ddbb6e2d07f2d3541c4ee5710c725819ec917"
 dependencies = [
  "darling 0.14.4",
  "proc-macro2",
@@ -4871,6 +4958,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
 
 [[package]]
+name = "no_std_io2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4894,9 +4990,9 @@ checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "ntapi"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
 ]
@@ -4934,7 +5030,7 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
 ]
 
@@ -4949,7 +5045,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -4965,9 +5061,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -5013,7 +5109,7 @@ dependencies = [
  "num-integer",
  "num-modular",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -5049,15 +5145,6 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
@@ -5067,16 +5154,18 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2858065e55c148d294a9f3aae3b0fa9458edadb41a108397094566f4e3c0dfb"
+checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bytes",
  "chrono",
  "form_urlencoded",
- "futures",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
  "http",
  "http-body-util",
  "httparse",
@@ -5087,14 +5176,14 @@ dependencies = [
  "parking_lot 0.12.5",
  "percent-encoding",
  "quick-xml",
- "rand 0.9.2",
- "reqwest 0.12.26",
+ "rand 0.10.1",
+ "reqwest 0.12.28",
  "ring",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
@@ -5114,9 +5203,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -5132,9 +5221,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "option-ext"
@@ -5163,7 +5252,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5293,10 +5382,10 @@ version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34b4653168b563151153c9e4c08ebed57fb8262bebfa79711552fa983c623e7a"
 dependencies = [
- "proc-macro-crate 3.4.0",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5353,14 +5442,14 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77144664f6aac5f629d7efa815f5098a054beeeca6ccafee5ec453fd2b0c53f9"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "ciborium",
  "coset",
  "data-encoding",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "hmac",
- "indexmap 2.12.1",
- "rand 0.8.5",
+ "indexmap 2.14.0",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -5380,7 +5469,7 @@ dependencies = [
  "group",
  "hex",
  "lazy_static",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "static_assertions",
  "subtle",
@@ -5447,9 +5536,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.4"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbcfd20a6d4eeba40179f05735784ad32bdaef05ce8e8af05f180d45bb3e7e22"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -5457,9 +5546,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.4"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f72981ade67b1ca6adc26ec221be9f463f2b5839c7508998daa17c23d94d7f"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
 dependencies = [
  "pest",
  "pest_generator",
@@ -5467,22 +5556,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.4"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee9efd8cdb50d719a80088b76f81aec7c41ed6d522ee750178f83883d271625"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.4"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf1d70880e76bdc13ba52eafa6239ce793d85c8e43896507e43dd8984ff05b82"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
  "sha2 0.10.9",
@@ -5515,7 +5604,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -5528,7 +5617,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5542,35 +5631,29 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkcs1"
@@ -5606,9 +5689,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "poly1305"
@@ -5616,7 +5699,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -5628,22 +5711,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -5672,6 +5755,16 @@ dependencies = [
  "hex",
  "primitive-types 0.12.2",
  "uint",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5719,11 +5812,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.23.10+spec-1.0.0",
+ "toml_edit 0.25.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -5769,14 +5862,14 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -5784,7 +5877,7 @@ dependencies = [
 [[package]]
 name = "product_common"
 version = "0.8.17"
-source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.17#7a67b7ff914aacb63522e95d74c0ac8733d28f33"
+source = "git+https://github.com/iotaledger/product-core.git?branch=feat%2Fiota-v1-23-rc-upstream-merge#b6d5bd7cacf2dde69c9bee1104920f8e0304a236"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5793,7 +5886,7 @@ dependencies = [
  "fastcrypto",
  "hyper",
  "iota-keys",
- "iota-sdk 1.22.1",
+ "iota-sdk 1.23.2",
  "iota-sdk-types",
  "iota_interaction",
  "iota_interaction_rust",
@@ -5801,7 +5894,7 @@ dependencies = [
  "itertools 0.13.0",
  "lazy_static",
  "phf",
- "reqwest 0.13.2",
+ "reqwest 0.13.4",
  "secret-storage",
  "serde",
  "serde_json",
@@ -5824,13 +5917,13 @@ dependencies = [
  "memchr",
  "parking_lot 0.12.5",
  "protobuf",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "prometheus-closure-metric"
-version = "1.22.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+version = "1.23.2"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -5838,9 +5931,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -5848,22 +5941,22 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "prost-types"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9b4db3d6da204ed77bb26ba83b6122a73aeb2e87e25fbf7ad2e84c4ccbf8f72"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
  "prost",
 ]
@@ -5890,9 +5983,9 @@ dependencies = [
 
 [[package]]
 name = "psm"
-version = "0.1.28"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d11f2fedc3b7dafdc2851bc52f277377c5473d378859be234bc7ebb593144d01"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
 dependencies = [
  "ar_archive_writer",
  "cc",
@@ -5915,9 +6008,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
  "serde",
@@ -5935,10 +6028,10 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.6.1",
- "thiserror 2.0.17",
+ "socket2 0.6.4",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -5946,20 +6039,20 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -5974,16 +6067,16 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -5993,6 +6086,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -6021,9 +6120,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -6032,12 +6131,23 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20 0.10.0",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -6067,7 +6177,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -6085,17 +6195,23 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_hc"
@@ -6130,14 +6246,14 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -6174,7 +6290,7 @@ checksum = "f2a62d85ed81ca5305dc544bd42c8804c5060b78ffa5ad3c64b0fb6a8c13d062"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6192,16 +6308,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec96166dafa0886eb81fe1c0a388bece180fbef2135f97c1e2cf8302e74b43b5"
-dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -6210,7 +6317,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libredox",
  "thiserror 1.0.69",
 ]
@@ -6232,14 +6339,14 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6249,9 +6356,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6260,15 +6367,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.12.26"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b4c14b2d9afca6a60277086b0cc6a6ae0b568f6f7916c943a8cdc79f8be240f"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -6297,8 +6404,8 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "tower 0.5.2",
- "tower-http 0.6.8",
+ "tower 0.5.3",
+ "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -6310,9 +6417,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -6328,8 +6435,8 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
- "tower 0.5.2",
- "tower-http 0.6.8",
+ "tower 0.5.3",
+ "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -6355,7 +6462,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -6378,9 +6485,9 @@ checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
 name = "roaring"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba9ce64a8f45d7fc86358410bb1a82e8c987504c0d4900e9141d69a9f26c885"
+checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -6435,12 +6542,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
-
-[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6448,9 +6549,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc-hex"
@@ -6478,11 +6579,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -6491,9 +6592,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.35"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "log",
  "once_cell",
@@ -6506,9 +6607,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9980d917ebb0c0536119ba501e90834767bffc3d60641457fd84a1f3fd337923"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -6518,9 +6619,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.2"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -6555,9 +6656,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -6572,9 +6673,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "salsa20"
@@ -6596,9 +6697,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -6630,9 +6731,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9558e172d4e8533736ba97870c4b2cd63f84b382a3d6eb063da41b91cce17289"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -6649,7 +6750,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6691,7 +6792,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.8.5",
+ "rand 0.8.6",
  "secp256k1-sys",
 ]
 
@@ -6711,16 +6812,16 @@ source = "git+https://github.com/iotaledger/secret-storage?tag=v0.3.0#7dc13ddae8
 dependencies = [
  "anyhow",
  "async-trait",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "security-framework"
-version = "3.5.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -6729,9 +6830,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.15.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -6739,9 +6840,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "send_wrapper"
@@ -6831,7 +6932,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6842,16 +6943,16 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
- "indexmap 2.12.1",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -6878,7 +6979,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6904,17 +7005,18 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.16.1"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
  "base64 0.22.1",
+ "bs58 0.5.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.12.1",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
- "schemars 1.1.0",
+ "schemars 1.2.1",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -6923,14 +7025,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.16.1"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6962,7 +7064,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -6974,7 +7076,7 @@ checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.9.0",
  "opaque-debug",
 ]
@@ -6986,18 +7088,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
 [[package]]
 name = "sha3"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
  "digest 0.10.7",
- "keccak",
+ "keccak 0.1.6",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.3",
+ "keccak 0.2.0",
 ]
 
 [[package]]
@@ -7008,10 +7120,11 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.7"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7664a098b8e616bdfcc2dc0e9ac44eb231eedf41db4e9fe95d8d32ec728dedad"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
 
@@ -7033,9 +7146,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "similar"
@@ -7051,9 +7164,9 @@ checksum = "16e78919e05c9b8e123d435a4ad104b488ad1585631830e413830985c214086e"
 
 [[package]]
 name = "siphasher"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "sized-chunks"
@@ -7067,9 +7180,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slip10_ed25519"
@@ -7104,12 +7217,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7124,7 +7237,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.8.5",
+ "rand 0.8.6",
  "sha1",
 ]
 
@@ -7171,27 +7284,27 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stacker"
-version = "0.1.22"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1f8b29fb42aafcea4edeeb6b2f2d7ecd0d969c48b4cf0d2e64aafc471dd6e59"
+checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
 dependencies = [
  "cc",
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "starfish-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "blake3",
  "fastcrypto",
  "iota-network-stack",
  "iota-sdk-types",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rs_merkle",
  "serde",
  "tracing",
@@ -7226,7 +7339,7 @@ dependencies = [
  "libsodium-sys-stable",
  "log",
  "nix",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "thiserror 1.0.69",
  "windows 0.36.1",
@@ -7239,7 +7352,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8300214898af5e153e7f66e49dbd1c6a21585f2d592d9f24f58b969792475ed6"
 dependencies = [
- "rand 0.8.5",
+ "rand 0.8.6",
  "stronghold-derive",
 ]
 
@@ -7301,7 +7414,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7313,7 +7426,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7341,9 +7454,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.111"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7367,7 +7480,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7416,9 +7529,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -7427,12 +7540,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -7449,12 +7562,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7468,11 +7581,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -7483,18 +7596,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7508,30 +7621,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.24"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -7547,7 +7660,7 @@ dependencies = [
  "hmac",
  "once_cell",
  "pbkdf2 0.11.0",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustc-hash 1.1.0",
  "sha2 0.10.9",
  "thiserror 1.0.69",
@@ -7567,9 +7680,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -7577,9 +7690,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -7592,29 +7705,30 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot 0.12.5",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.1",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7629,9 +7743,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -7641,9 +7755,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
@@ -7653,9 +7767,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
@@ -7688,9 +7802,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.4+spec-1.0.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe3cea6b2aa3b910092f6abd4053ea464fab5f9c170ba5e9a6aead16ec4af2b6"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -7701,7 +7815,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.12.1",
+ "indexmap 2.14.0",
  "toml_datetime 0.6.11",
  "winnow 0.5.40",
 ]
@@ -7712,33 +7826,33 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.12.1",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned",
  "toml_datetime 0.6.11",
  "toml_write",
- "winnow 0.7.14",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
- "indexmap 2.12.1",
- "toml_datetime 0.7.4+spec-1.0.0",
+ "indexmap 2.14.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 0.7.14",
+ "winnow 1.0.3",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.5+spec-1.0.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c03bee5ce3696f31250db0bbaff18bc43301ce0e8db2ed1f07cbb2acf89984c"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 0.7.14",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -7749,9 +7863,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
-version = "0.14.2"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7613188ce9f7df5bfe185db26c5814347d110db17920415cf2fbcad85e7203"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "axum",
@@ -7766,11 +7880,11 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "socket2 0.6.1",
+ "socket2 0.6.4",
  "sync_wrapper",
  "tokio",
  "tokio-stream",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -7779,9 +7893,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-health"
-version = "0.14.2"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a82868bf299e0a1d2e8dce0dc33a46c02d6f045b2c1f1d6cc8dc3d0bf1812ef"
+checksum = "fcfab99db777fba2802f0dfa861d1628d1ae916fb199d29819941f139ae85082"
 dependencies = [
  "prost",
  "tokio",
@@ -7792,9 +7906,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.2"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66bd50ad6ce1252d87ef024b3d64fe4c3cf54a86fb9ef4c631fdd0ded7aeaa67"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
  "prost",
@@ -7813,7 +7927,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand 0.8.6",
  "slab",
  "tokio",
  "tokio-util",
@@ -7824,13 +7938,13 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.12.1",
+ "indexmap 2.14.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -7847,7 +7961,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "bytes",
  "http",
  "http-body",
@@ -7861,20 +7975,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -7909,7 +8023,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7940,25 +8054,30 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.4",
  "sha1",
- "thiserror 2.0.17",
- "utf-8",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
 name = "typed-store-error"
-version = "1.22.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.22.1#683996908751ff12d77e725e93b33758bdbd26dc"
+version = "1.23.2"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
 dependencies = [
  "serde",
  "thiserror 1.0.69",
@@ -7972,15 +8091,15 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "typeshare"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19be0f411120091e76e13e5a0186d8e2bcc3e7e244afdb70152197f1a8486ceb"
+checksum = "da1bf9fe204f358ffea7f8f779b53923a20278b3ab8e8d97962c5e1b3a54edb7"
 dependencies = [
  "chrono",
  "serde",
@@ -7995,7 +8114,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "621963e302416b389a1ec177397e9e62de849a78bd8205d428608553def75350"
 dependencies = [
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8024,9 +8143,9 @@ checksum = "ccb97dac3243214f8d8507998906ca3e2e0b900bf9bf4870477f125b82e68f6e"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-normalization"
@@ -8036,6 +8155,12 @@ checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"
@@ -8055,7 +8180,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -8073,22 +8198,22 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "3.1.4"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39cb1dbab692d82a977c0392ffac19e188bd9186a9f32806f0aaa859d75585a"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64 0.22.1",
  "log",
  "percent-encoding",
  "ureq-proto",
- "utf-8",
+ "utf8-zero",
 ]
 
 [[package]]
 name = "ureq-proto"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
  "base64 0.22.1",
  "http",
@@ -8098,21 +8223,22 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.7"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
-name = "utf-8"
-version = "0.7.6"
+name = "utf8-zero"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -8128,13 +8254,13 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.19.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "js-sys",
- "rand 0.9.2",
+ "rand 0.10.1",
  "wasm-bindgen",
 ]
 
@@ -8146,7 +8272,7 @@ checksum = "a1935e10c6f04d22688d07c0790f2fc0e1b1c5c2c55bc0cc87ed67656e587dd8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8210,11 +8336,20 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -8265,7 +8400,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -8279,6 +8414,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.14.0",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
 name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8289,6 +8446,18 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.1",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+ "semver",
 ]
 
 [[package]]
@@ -8317,23 +8486,23 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
 dependencies = [
- "webpki-root-certs 1.0.4",
+ "webpki-root-certs 1.0.7",
 ]
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.4"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee3e3b5f5e80bc89f30ce8d0343bf4e5f12341c51f3e26cbeecbc7c85443e85b"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.4"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -8425,7 +8594,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8436,7 +8605,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8447,7 +8616,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8458,7 +8627,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8832,24 +9001,121 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap 2.14.0",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.1",
+ "indexmap 2.14.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wyz"
@@ -8890,7 +9156,7 @@ dependencies = [
  "nom",
  "oid-registry",
  "rusticata-macros",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -8924,9 +9190,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -8935,54 +9201,54 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.31"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
+checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.31"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
+checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -8998,20 +9264,20 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -9020,9 +9286,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -9031,34 +9297,34 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "zip"
-version = "6.0.0"
+version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
- "arbitrary",
  "crc32fast",
  "flate2",
- "indexmap 2.12.1",
+ "indexmap 2.14.0",
  "memchr",
+ "typed-path",
  "zopfli",
 ]
 
 [[package]]
 name = "zlib-rs"
-version = "0.5.4"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f936044d677be1a1168fae1d03b583a285a5dd9d8cbf7b24c23aa1fc775235"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3768,8 +3768,8 @@ dependencies = [
 
 [[package]]
 name = "iota_interaction"
-version = "0.8.17"
-source = "git+https://github.com/iotaledger/product-core.git?branch=feat%2Fiota-v1-23-rc-upstream-merge#b6d5bd7cacf2dde69c9bee1104920f8e0304a236"
+version = "0.8.18"
+source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.18#9518c0a4544d2d25bdc0b6cc3af250fa39ec9ddf"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3812,8 +3812,8 @@ dependencies = [
 
 [[package]]
 name = "iota_interaction_rust"
-version = "0.8.17"
-source = "git+https://github.com/iotaledger/product-core.git?branch=feat%2Fiota-v1-23-rc-upstream-merge#b6d5bd7cacf2dde69c9bee1104920f8e0304a236"
+version = "0.8.18"
+source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.18#9518c0a4544d2d25bdc0b6cc3af250fa39ec9ddf"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3826,8 +3826,8 @@ dependencies = [
 
 [[package]]
 name = "iota_interaction_ts"
-version = "0.8.17"
-source = "git+https://github.com/iotaledger/product-core.git?branch=feat%2Fiota-v1-23-rc-upstream-merge#b6d5bd7cacf2dde69c9bee1104920f8e0304a236"
+version = "0.8.18"
+source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.18#9518c0a4544d2d25bdc0b6cc3af250fa39ec9ddf"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5876,8 +5876,8 @@ dependencies = [
 
 [[package]]
 name = "product_common"
-version = "0.8.17"
-source = "git+https://github.com/iotaledger/product-core.git?branch=feat%2Fiota-v1-23-rc-upstream-merge#b6d5bd7cacf2dde69c9bee1104920f8e0304a236"
+version = "0.8.18"
+source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.18#9518c0a4544d2d25bdc0b6cc3af250fa39ec9ddf"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,17 +17,17 @@ async-trait = "0.1"
 bcs = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 hyper = "1.8"
-iota-sdk = { package = "iota-sdk", git = "https://github.com/iotaledger/iota.git", tag = "v1.22.1" }
-iota_interaction = { package = "iota_interaction", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.17", default-features = false }
-iota_interaction_rust = { package = "iota_interaction_rust", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.17", default-features = false }
-iota_interaction_ts = { package = "iota_interaction_ts", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.17", default-features = false }
-product_common = { package = "product_common", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.17", default-features = false }
+iota-sdk = { package = "iota-sdk", git = "https://github.com/iotaledger/iota.git", tag = "v1.23.2" }
+iota_interaction = { package = "iota_interaction", git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-23-rc-upstream-merge", default-features = false }
+iota_interaction_rust = { package = "iota_interaction_rust", git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-23-rc-upstream-merge", default-features = false }
+iota_interaction_ts = { package = "iota_interaction_ts", git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-23-rc-upstream-merge", default-features = false }
+product_common = { package = "product_common", git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-23-rc-upstream-merge", default-features = false }
 secret-storage = { git = "https://github.com/iotaledger/secret-storage", tag = "v0.3.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.149"
 strum = { version = "0.27", default-features = false, features = ["derive", "std"] }
 thiserror = "2.0"
-tokio = { version = "1.49.0", default-features = false, features = ["sync"] }
+tokio = { version = "1.52.2", default-features = false, features = ["sync"] }
 
 [profile.release.package.iota_interaction_ts]
 opt-level = "s"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,10 @@ bcs = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 hyper = "1.8"
 iota-sdk = { package = "iota-sdk", git = "https://github.com/iotaledger/iota.git", tag = "v1.23.2" }
-iota_interaction = { package = "iota_interaction", git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-23-rc-upstream-merge", default-features = false }
-iota_interaction_rust = { package = "iota_interaction_rust", git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-23-rc-upstream-merge", default-features = false }
-iota_interaction_ts = { package = "iota_interaction_ts", git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-23-rc-upstream-merge", default-features = false }
-product_common = { package = "product_common", git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-23-rc-upstream-merge", default-features = false }
+iota_interaction = { package = "iota_interaction", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.18", default-features = false }
+iota_interaction_rust = { package = "iota_interaction_rust", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.18", default-features = false }
+iota_interaction_ts = { package = "iota_interaction_ts", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.18", default-features = false }
+product_common = { package = "product_common", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.18", default-features = false }
 secret-storage = { git = "https://github.com/iotaledger/secret-storage", tag = "v0.3.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.149"

--- a/bindings/wasm/hierarchies_wasm/Cargo.toml
+++ b/bindings/wasm/hierarchies_wasm/Cargo.toml
@@ -19,8 +19,8 @@ crate-type = ["cdylib", "rlib"]
 anyhow = "1.0"
 console_error_panic_hook = "0.1"
 hyper = "1.8"
-iota_interaction = { package = "iota_interaction", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.17", default-features = false }
-iota_interaction_ts = { package = "iota_interaction_ts", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.17" }
+iota_interaction = { package = "iota_interaction", git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-23-rc-upstream-merge", default-features = false }
+iota_interaction_ts = { package = "iota_interaction_ts", git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-23-rc-upstream-merge" }
 js-sys = { version = "=0.3.85" }
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6"
@@ -35,7 +35,7 @@ features = ["default-http-client", "gas-station"]
 [dependencies.product_common]
 package = "product_common"
 git = "https://github.com/iotaledger/product-core.git"
-tag = "v0.8.17"
+branch = "feat/iota-v1-23-rc-upstream-merge"
 features = [
   "default-http-client",
   "binding-utils",

--- a/bindings/wasm/hierarchies_wasm/Cargo.toml
+++ b/bindings/wasm/hierarchies_wasm/Cargo.toml
@@ -19,8 +19,8 @@ crate-type = ["cdylib", "rlib"]
 anyhow = "1.0"
 console_error_panic_hook = "0.1"
 hyper = "1.8"
-iota_interaction = { package = "iota_interaction", git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-23-rc-upstream-merge", default-features = false }
-iota_interaction_ts = { package = "iota_interaction_ts", git = "https://github.com/iotaledger/product-core.git", branch = "feat/iota-v1-23-rc-upstream-merge" }
+iota_interaction = { package = "iota_interaction", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.18", default-features = false }
+iota_interaction_ts = { package = "iota_interaction_ts", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.18" }
 js-sys = { version = "=0.3.85" }
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6"
@@ -35,7 +35,7 @@ features = ["default-http-client", "gas-station"]
 [dependencies.product_common]
 package = "product_common"
 git = "https://github.com/iotaledger/product-core.git"
-branch = "feat/iota-v1-23-rc-upstream-merge"
+tag = "v0.8.18"
 features = [
   "default-http-client",
   "binding-utils",

--- a/bindings/wasm/hierarchies_wasm/package-lock.json
+++ b/bindings/wasm/hierarchies_wasm/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.1.10",
             "license": "Apache-2.0",
             "dependencies": {
-                "@iota/iota-interaction-ts": "^0.13.0"
+                "@iota/iota-interaction-ts": "^0.14.0"
             },
             "devDependencies": {
                 "@types/lodash": "^4.17.20",
@@ -277,21 +277,21 @@
             }
         },
         "node_modules/@iota/iota-interaction-ts": {
-            "version": "0.13.0",
-            "resolved": "https://registry.npmjs.org/@iota/iota-interaction-ts/-/iota-interaction-ts-0.13.0.tgz",
-            "integrity": "sha512-LL4nbgEbqqa3UqXkiAnbRMW3KSqKMic0cJEEooWlTz2VtwHSOHyVwzjF2HNt7C9o2svq5uKyCkkzVAxjMI1Esg==",
+            "version": "0.14.0",
+            "resolved": "https://registry.npmjs.org/@iota/iota-interaction-ts/-/iota-interaction-ts-0.14.0.tgz",
+            "integrity": "sha512-LojlV7UL/cMERaJqw1IBeL9bWSJPJ91kiOQ6kWTUH775kuWLixx0JBJJINGpbQVZXIsUV0T62nbipVfk+JferA==",
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=20"
             },
             "peerDependencies": {
-                "@iota/iota-sdk": "^1.13.0"
+                "@iota/iota-sdk": "^1.14.0"
             }
         },
         "node_modules/@iota/iota-sdk": {
-            "version": "1.13.0",
-            "resolved": "https://registry.npmjs.org/@iota/iota-sdk/-/iota-sdk-1.13.0.tgz",
-            "integrity": "sha512-ay19PRu0z+1W9tnmGyexIR/Sp0Rpt7H0mUCuEZQ5B+7O6Qf61+Co8TrR1SRIrKwD7Fu90jPy5y5MwFXy/vLwKg==",
+            "version": "1.14.0",
+            "resolved": "https://registry.npmjs.org/@iota/iota-sdk/-/iota-sdk-1.14.0.tgz",
+            "integrity": "sha512-nOq7EHD68p35nH+2c1sn/MnvEFEkRNRXTuiDYqI+SxWN1KcDuyYaSoFqz9PsQNhbdXzgbseHMo/L94LJ5jgIuA==",
             "license": "Apache-2.0",
             "peer": true,
             "dependencies": {

--- a/bindings/wasm/hierarchies_wasm/package.json
+++ b/bindings/wasm/hierarchies_wasm/package.json
@@ -74,7 +74,7 @@
         "wasm-opt": "^1.4.0"
     },
     "dependencies": {
-        "@iota/iota-interaction-ts": "^0.13.0"
+        "@iota/iota-interaction-ts": "^0.14.0"
     },
     "peerDependencies": {
         "@iota/iota-sdk": "^1.13.0"

--- a/hierarchies-rs/examples/real-world/01_university_degrees.rs
+++ b/hierarchies-rs/examples/real-world/01_university_degrees.rs
@@ -272,8 +272,8 @@ async fn main() -> anyhow::Result<()> {
     // =============================================================================
     println!("🏛️ Step 3: Adding universities to the consortium...");
 
-    let harvard_address = IotaAddress::random_for_testing_only();
-    let mit_address = IotaAddress::random_for_testing_only();
+    let harvard_address = IotaAddress::random();
+    let mit_address = IotaAddress::random();
 
     // Add Harvard as root authority
     hierarchies_client
@@ -297,7 +297,7 @@ async fn main() -> anyhow::Result<()> {
     println!("🏫 Step 4: Creating faculty-level accreditations...");
 
     // Simulate Harvard CS Faculty address
-    let harvard_cs_faculty = IotaAddress::random_for_testing_only();
+    let harvard_cs_faculty = IotaAddress::random();
 
     // Harvard delegates accreditation rights to its CS Faculty
     // This allows the faculty to further delegate to registrars and professors
@@ -330,7 +330,7 @@ async fn main() -> anyhow::Result<()> {
     println!("👨‍💼 Step 5: Creating registrar attestation rights...");
 
     // Simulate Harvard CS Registrar address
-    let harvard_cs_registrar = IotaAddress::random_for_testing_only();
+    let harvard_cs_registrar = IotaAddress::random();
 
     // CS Faculty delegates attestation rights to the CS Registrar
     // Registrar can now create attestations (issue degrees) but not delegate further
@@ -353,8 +353,8 @@ async fn main() -> anyhow::Result<()> {
     println!("🎓 Step 6: Issuing student degrees...");
 
     // Simulate student addresses
-    let alice_student = IotaAddress::random_for_testing_only();
-    let bob_student = IotaAddress::random_for_testing_only();
+    let alice_student = IotaAddress::random();
+    let bob_student = IotaAddress::random();
 
     println!("📜 Issuing Bachelor's degree in Computer Science to Alice...");
 

--- a/hierarchies-rs/examples/real-world/02_supply_chain.rs
+++ b/hierarchies-rs/examples/real-world/02_supply_chain.rs
@@ -363,9 +363,9 @@ async fn main() -> anyhow::Result<()> {
     println!("🌐 Step 3: Adding regional standards organizations...");
 
     // Simulate regional standards organization addresses
-    let iso_europe = IotaAddress::random_for_testing_only();
-    let iso_americas = IotaAddress::random_for_testing_only();
-    let iso_asia_pacific = IotaAddress::random_for_testing_only();
+    let iso_europe = IotaAddress::random();
+    let iso_americas = IotaAddress::random();
+    let iso_asia_pacific = IotaAddress::random();
 
     // Add regional organizations as root authorities
     hierarchies_client
@@ -394,7 +394,7 @@ async fn main() -> anyhow::Result<()> {
     println!("🏢 Step 4: Creating national testing institute accreditations...");
 
     // German Testing Institute under ISO Europe
-    let german_testing_institute = IotaAddress::random_for_testing_only();
+    let german_testing_institute = IotaAddress::random();
 
     // Create comprehensive accreditation package for German institute
     let european_cert_properties = vec![
@@ -419,7 +419,7 @@ async fn main() -> anyhow::Result<()> {
         .await?;
 
     // US FDA Regional Office under ISO Americas
-    let us_fda_regional = IotaAddress::random_for_testing_only();
+    let us_fda_regional = IotaAddress::random();
 
     let americas_cert_properties = vec![
         FederationProperty::new(iso_9001.clone()).with_allow_any(true),
@@ -452,7 +452,7 @@ async fn main() -> anyhow::Result<()> {
     println!("🧪 Step 5: Creating local testing laboratory rights...");
 
     // Berlin Food Safety Lab under German Testing Institute
-    let berlin_food_lab = IotaAddress::random_for_testing_only();
+    let berlin_food_lab = IotaAddress::random();
 
     // Focus on food safety and organic certifications
     let food_safety_properties = vec![
@@ -475,7 +475,7 @@ async fn main() -> anyhow::Result<()> {
         .await?;
 
     // California Agricultural Lab under US FDA
-    let california_ag_lab = IotaAddress::random_for_testing_only();
+    let california_ag_lab = IotaAddress::random();
 
     hierarchies_client
         .create_accreditation_to_attest(
@@ -498,8 +498,8 @@ async fn main() -> anyhow::Result<()> {
     println!("🥕 Step 6: Issuing product certifications...");
 
     // Simulate product batch addresses/IDs
-    let organic_apples_batch = IotaAddress::random_for_testing_only();
-    let processed_food_batch = IotaAddress::random_for_testing_only();
+    let organic_apples_batch = IotaAddress::random();
+    let processed_food_batch = IotaAddress::random();
 
     // Current time for certification
     let now = Utc::now();

--- a/hierarchies-rs/examples/validation/02_validate_properties.rs
+++ b/hierarchies-rs/examples/validation/02_validate_properties.rs
@@ -67,7 +67,7 @@ async fn main() -> anyhow::Result<()> {
     let properties = [(property_name.clone(), value)];
 
     let validate = hierarchies_client
-        .validate_properties(*federation_id, (*receiver).into(), properties)
+        .validate_properties(*federation_id, receiver, properties)
         .await;
 
     assert!(validate.is_ok());
@@ -78,7 +78,7 @@ async fn main() -> anyhow::Result<()> {
     let invalid_property_value = PropertyValue::Text("Invalid Property Value".to_owned());
     let invalid_properties = [(property_name, invalid_property_value)];
     let validate_invalid_property_value = hierarchies_client
-        .validate_properties(*federation_id, (*receiver).into(), invalid_properties)
+        .validate_properties(*federation_id, receiver, invalid_properties)
         .await;
     assert!(validate_invalid_property_value.is_ok());
     println!("Validated invalid property value");

--- a/hierarchies-rs/hierarchies/src/client/read_only.rs
+++ b/hierarchies-rs/hierarchies/src/client/read_only.rs
@@ -279,7 +279,7 @@ impl HierarchiesClientReadOnly {
         let inspection_result = self
             .client
             .read_api()
-            .dev_inspect_transaction_block(IotaAddress::ZERO, TransactionKind::programmable(tx), None, None, None)
+            .dev_inspect_transaction_block(IotaAddress::ZERO, TransactionKind::Programmable(tx), None, None, None)
             .await
             .map_err(|err| ClientError::ExecutionFailed {
                 reason: format!("Failed to inspect transaction block: {err}"),

--- a/hierarchies-rs/hierarchies/src/core/mod.rs
+++ b/hierarchies-rs/hierarchies/src/core/mod.rs
@@ -13,15 +13,15 @@ pub mod types;
 // Re-export error types for convenience
 pub use error::{CapabilityError, OperationError};
 use iota_interaction::types::programmable_transaction_builder::ProgrammableTransactionBuilder as Ptb;
-use iota_interaction::types::transaction::{Argument, ObjectArg};
+use iota_interaction::types::transaction::{Argument, CallArg, SharedObjectRef};
 use iota_interaction::types::{IOTA_CLOCK_OBJECT_ID, IOTA_CLOCK_OBJECT_SHARED_VERSION};
 
 /// Adds a reference to the on-chain clock to `ptb`'s arguments.
 pub(crate) fn get_clock_ref(ptb: &mut Ptb) -> Argument {
-    ptb.obj(ObjectArg::SharedObject {
-        id: IOTA_CLOCK_OBJECT_ID,
+    ptb.obj(CallArg::Shared(SharedObjectRef {
+        object_id: IOTA_CLOCK_OBJECT_ID,
         initial_shared_version: IOTA_CLOCK_OBJECT_SHARED_VERSION,
         mutable: false,
-    })
+    }))
     .expect("network has a singleton clock instantiated")
 }

--- a/hierarchies-rs/hierarchies/src/core/operations.rs
+++ b/hierarchies-rs/hierarchies/src/core/operations.rs
@@ -22,7 +22,7 @@ use iota_interaction::rpc_types::IotaObjectDataOptions;
 use iota_interaction::types::base_types::{IotaAddress, ObjectID, ObjectRef, SequenceNumber};
 use iota_interaction::types::object::Owner;
 use iota_interaction::types::programmable_transaction_builder::ProgrammableTransactionBuilder;
-use iota_interaction::types::transaction::{CallArg, Command, ObjectArg, ProgrammableTransaction};
+use iota_interaction::types::transaction::{CallArg, Command, ProgrammableTransaction, SharedObjectRef};
 use iota_interaction::{IotaClientTrait, MoveType, OptionalSync, ident_str};
 use product_common::core_client::CoreClientReadOnly;
 
@@ -83,7 +83,7 @@ impl HierarchiesImpl {
             .get_object_ref_by_id(object_id)
             .await
             .map_err(|e| CapabilityError::Rpc { source: e.into() })?
-            .map(|owned_ref| owned_ref.reference.to_object_ref())
+            .map(|owned_ref| owned_ref.reference)
             .ok_or_else(|| CapabilityError::NotFound {
                 cap_type: ROOT_AUTHORITY_CAP_TYPE.to_string(),
             })
@@ -118,7 +118,7 @@ impl HierarchiesImpl {
             .get_object_ref_by_id(object_id)
             .await
             .map_err(|e| CapabilityError::Rpc { source: e.into() })?
-            .map(|owned_ref| owned_ref.reference.to_object_ref())
+            .map(|owned_ref| owned_ref.reference)
             .ok_or_else(|| CapabilityError::NotFound {
                 cap_type: ACCREDIT_CAP_TYPE.to_string(),
             })
@@ -133,17 +133,17 @@ impl HierarchiesImpl {
     /// # Errors
     ///
     /// Returns an error if the federation object is not found or not shared.
-    async fn get_fed_ref<C>(client: &C, federation_id: ObjectID) -> Result<ObjectArg, OperationError>
+    async fn get_fed_ref<C>(client: &C, federation_id: ObjectID) -> Result<CallArg, OperationError>
     where
         C: CoreClientReadOnly + OptionalSync,
     {
-        let fed_ref = ObjectArg::SharedObject {
-            id: federation_id,
+        let fed_ref = CallArg::Shared(SharedObjectRef {
+            object_id: federation_id,
             initial_shared_version: HierarchiesImpl::initial_shared_version(client, &federation_id)
                 .await
                 .map_err(|e| OperationError::Object(ObjectError::RetrievalFailed { source: Box::new(e) }))?,
             mutable: true,
-        };
+        });
 
         Ok(fed_ref)
     }
@@ -173,7 +173,7 @@ impl HierarchiesImpl {
             })?;
 
         match owner {
-            Owner::Shared { initial_shared_version } => Ok(initial_shared_version),
+            Owner::Shared(initial_shared_version) => Ok(initial_shared_version),
             _ => Err(ObjectError::WrongType {
                 expected: "SharedObject".to_string(),
                 actual: "ImmOrOwnedObject".to_string(),
@@ -214,8 +214,8 @@ pub(crate) trait HierarchiesOperations {
 
         ptb.move_call(
             package_id,
-            ident_str!(move_names::MODULE_MAIN).into(),
-            ident_str!("new_federation").into(),
+            ident_str!(move_names::MODULE_MAIN).as_str().into(),
+            ident_str!("new_federation").as_str().into(),
             vec![],
             vec![],
         )?;
@@ -248,7 +248,7 @@ pub(crate) trait HierarchiesOperations {
         let mut ptb = ProgrammableTransactionBuilder::new();
 
         let cap = HierarchiesImpl::get_root_authority_cap(client, owner, federation_id).await?;
-        let cap = ptb.obj(ObjectArg::ImmOrOwnedObject(cap))?;
+        let cap = ptb.obj(CallArg::ImmutableOrOwned(cap))?;
 
         let fed_ref = HierarchiesImpl::get_fed_ref(client, federation_id).await?;
         let fed_ref = ptb.obj(fed_ref)?;
@@ -256,8 +256,8 @@ pub(crate) trait HierarchiesOperations {
 
         ptb.programmable_move_call(
             client.package_id(),
-            ident_str!(move_names::MODULE_MAIN).into(),
-            ident_str!("add_property").into(),
+            ident_str!(move_names::MODULE_MAIN).as_str().into(),
+            ident_str!("add_property").as_str().into(),
             vec![],
             vec![fed_ref, cap, property],
         );
@@ -285,7 +285,7 @@ pub(crate) trait HierarchiesOperations {
 
         let cap = HierarchiesImpl::get_accredit_cap(client, owner, federation_id).await?;
 
-        let cap = ptb.obj(ObjectArg::ImmOrOwnedObject(cap))?;
+        let cap = ptb.obj(CallArg::ImmutableOrOwned(cap))?;
 
         let fed_ref = HierarchiesImpl::get_fed_ref(client, federation_id).await?;
         let fed_ref = ptb.obj(fed_ref)?;
@@ -295,8 +295,8 @@ pub(crate) trait HierarchiesOperations {
         let clock = get_clock_ref(&mut ptb);
         ptb.programmable_move_call(
             client.package_id(),
-            ident_str!(move_names::MODULE_MAIN).into(),
-            ident_str!("revoke_accreditation_to_attest").into(),
+            ident_str!(move_names::MODULE_MAIN).as_str().into(),
+            ident_str!("revoke_accreditation_to_attest").as_str().into(),
             vec![],
             vec![fed_ref, cap, user_id_arg, permission_id, clock],
         );
@@ -329,7 +329,7 @@ pub(crate) trait HierarchiesOperations {
 
         let cap = HierarchiesImpl::get_root_authority_cap(client, owner, federation_id).await?;
 
-        let cap = ptb.obj(ObjectArg::ImmOrOwnedObject(cap))?;
+        let cap = ptb.obj(CallArg::ImmutableOrOwned(cap))?;
 
         let fed_ref = HierarchiesImpl::get_fed_ref(client, federation_id).await?;
         let fed_ref = ptb.obj(fed_ref)?;
@@ -338,8 +338,8 @@ pub(crate) trait HierarchiesOperations {
 
         ptb.programmable_move_call(
             client.package_id(),
-            ident_str!(move_names::MODULE_MAIN).into(),
-            ident_str!("add_root_authority").into(),
+            ident_str!(move_names::MODULE_MAIN).as_str().into(),
+            ident_str!("add_root_authority").as_str().into(),
             vec![],
             vec![fed_ref, cap, account_id_arg],
         );
@@ -372,7 +372,7 @@ pub(crate) trait HierarchiesOperations {
         let cap = HierarchiesImpl::get_accredit_cap(client, owner, federation_id).await?;
         let clock = get_clock_ref(&mut ptb);
 
-        let cap = ptb.obj(ObjectArg::ImmOrOwnedObject(cap))?;
+        let cap = ptb.obj(CallArg::ImmutableOrOwned(cap))?;
 
         let fed_ref = HierarchiesImpl::get_fed_ref(client, federation_id).await?;
         let fed_ref = ptb.obj(fed_ref)?;
@@ -383,8 +383,8 @@ pub(crate) trait HierarchiesOperations {
 
         ptb.programmable_move_call(
             client.package_id(),
-            ident_str!(move_names::MODULE_MAIN).into(),
-            ident_str!("create_accreditation_to_accredit").into(),
+            ident_str!(move_names::MODULE_MAIN).as_str().into(),
+            ident_str!("create_accreditation_to_accredit").as_str().into(),
             vec![],
             vec![fed_ref, cap, receiver_arg, want_properties, clock],
         );
@@ -416,7 +416,7 @@ pub(crate) trait HierarchiesOperations {
 
         let cap = HierarchiesImpl::get_accredit_cap(client, owner, federation_id).await?;
         let clock = get_clock_ref(&mut ptb);
-        let cap = ptb.obj(ObjectArg::ImmOrOwnedObject(cap))?;
+        let cap = ptb.obj(CallArg::ImmutableOrOwned(cap))?;
 
         let fed_ref = HierarchiesImpl::get_fed_ref(client, federation_id).await?;
         let fed_ref = ptb.obj(fed_ref)?;
@@ -427,8 +427,8 @@ pub(crate) trait HierarchiesOperations {
 
         ptb.programmable_move_call(
             client.package_id(),
-            ident_str!(move_names::MODULE_MAIN).into(),
-            ident_str!("create_accreditation_to_attest").into(),
+            ident_str!(move_names::MODULE_MAIN).as_str().into(),
+            ident_str!("create_accreditation_to_attest").as_str().into(),
             vec![],
             vec![fed_ref, cap, receiver_arg, want_properties, clock],
         );
@@ -460,7 +460,7 @@ pub(crate) trait HierarchiesOperations {
 
         let cap = HierarchiesImpl::get_accredit_cap(client, owner, federation_id).await?;
         let clock = get_clock_ref(&mut ptb);
-        let cap = ptb.obj(ObjectArg::ImmOrOwnedObject(cap))?;
+        let cap = ptb.obj(CallArg::ImmutableOrOwned(cap))?;
 
         let fed_ref = HierarchiesImpl::get_fed_ref(client, federation_id).await?;
         let fed_ref = ptb.obj(fed_ref)?;
@@ -470,8 +470,8 @@ pub(crate) trait HierarchiesOperations {
 
         ptb.programmable_move_call(
             client.package_id(),
-            ident_str!(move_names::MODULE_MAIN).into(),
-            ident_str!("revoke_accreditation_to_accredit").into(),
+            ident_str!(move_names::MODULE_MAIN).as_str().into(),
+            ident_str!("revoke_accreditation_to_accredit").as_str().into(),
             vec![],
             vec![fed_ref, cap, user_id_arg, accreditation_id, clock],
         );
@@ -497,12 +497,11 @@ pub(crate) trait HierarchiesOperations {
         let mut ptb = ProgrammableTransactionBuilder::new();
 
         let fed_ref = HierarchiesImpl::get_fed_ref(client, federation_id).await?;
-        let fed_ref = CallArg::Object(fed_ref);
 
         ptb.move_call(
             client.package_id(),
-            ident_str!(move_names::MODULE_MAIN).into(),
-            ident_str!("get_properties").into(),
+            ident_str!(move_names::MODULE_MAIN).as_str().into(),
+            ident_str!("get_properties").as_str().into(),
             vec![],
             vec![fed_ref],
         )?;
@@ -538,13 +537,12 @@ pub(crate) trait HierarchiesOperations {
         let mut ptb = ProgrammableTransactionBuilder::new();
 
         let fed_ref = HierarchiesImpl::get_fed_ref(client, federation_id).await?;
-        let fed_ref = CallArg::Object(fed_ref);
         let property_name = CallArg::Pure(bcs::to_bytes(&property_name)?);
 
         ptb.move_call(
             client.package_id(),
-            ident_str!(move_names::MODULE_MAIN).into(),
-            ident_str!("is_property_in_federation").into(),
+            ident_str!(move_names::MODULE_MAIN).as_str().into(),
+            ident_str!("is_property_in_federation").as_str().into(),
             vec![],
             vec![fed_ref, property_name],
         )?;
@@ -579,13 +577,12 @@ pub(crate) trait HierarchiesOperations {
         let mut ptb = ProgrammableTransactionBuilder::new();
 
         let fed_ref = HierarchiesImpl::get_fed_ref(client, federation_id).await?;
-        let fed_ref = CallArg::Object(fed_ref);
         let user_id = CallArg::Pure(bcs::to_bytes(&user_id)?);
 
         ptb.move_call(
             client.package_id(),
-            ident_str!(move_names::MODULE_MAIN).into(),
-            ident_str!("get_accreditations_to_attest").into(),
+            ident_str!(move_names::MODULE_MAIN).as_str().into(),
+            ident_str!("get_accreditations_to_attest").as_str().into(),
             vec![],
             vec![fed_ref, user_id],
         )?;
@@ -609,13 +606,12 @@ pub(crate) trait HierarchiesOperations {
         let mut ptb = ProgrammableTransactionBuilder::new();
 
         let fed_ref = HierarchiesImpl::get_fed_ref(client, federation_id).await?;
-        let fed_ref = CallArg::Object(fed_ref);
         let user_id = CallArg::Pure(bcs::to_bytes(&user_id)?);
 
         ptb.move_call(
             client.package_id(),
-            ident_str!(move_names::MODULE_MAIN).into(),
-            ident_str!("is_attester").into(),
+            ident_str!(move_names::MODULE_MAIN).as_str().into(),
+            ident_str!("is_attester").as_str().into(),
             vec![],
             vec![fed_ref, user_id],
         )?;
@@ -651,13 +647,12 @@ pub(crate) trait HierarchiesOperations {
         let mut ptb = ProgrammableTransactionBuilder::new();
 
         let fed_ref = HierarchiesImpl::get_fed_ref(client, federation_id).await?;
-        let fed_ref = CallArg::Object(fed_ref);
         let user_id = CallArg::Pure(bcs::to_bytes(&user_id)?);
 
         ptb.move_call(
             client.package_id(),
-            ident_str!(move_names::MODULE_MAIN).into(),
-            ident_str!("get_accreditations_to_accredit").into(),
+            ident_str!(move_names::MODULE_MAIN).as_str().into(),
+            ident_str!("get_accreditations_to_accredit").as_str().into(),
             vec![],
             vec![fed_ref, user_id],
         )?;
@@ -681,13 +676,12 @@ pub(crate) trait HierarchiesOperations {
         let mut ptb = ProgrammableTransactionBuilder::new();
 
         let fed_ref = HierarchiesImpl::get_fed_ref(client, federation_id).await?;
-        let fed_ref = CallArg::Object(fed_ref);
         let user_id = CallArg::Pure(bcs::to_bytes(&user_id)?);
 
         ptb.move_call(
             client.package_id(),
-            ident_str!(move_names::MODULE_MAIN).into(),
-            ident_str!("is_accreditor").into(),
+            ident_str!(move_names::MODULE_MAIN).as_str().into(),
+            ident_str!("is_accreditor").as_str().into(),
             vec![],
             vec![fed_ref, user_id],
         )?;
@@ -724,7 +718,7 @@ pub(crate) trait HierarchiesOperations {
 
         let cap = HierarchiesImpl::get_root_authority_cap(client, owner, federation_id).await?;
 
-        let cap = ptb.obj(ObjectArg::ImmOrOwnedObject(cap))?;
+        let cap = ptb.obj(CallArg::ImmutableOrOwned(cap))?;
 
         let fed_ref = HierarchiesImpl::get_fed_ref(client, federation_id).await?;
         let fed_ref = ptb.obj(fed_ref)?;
@@ -735,8 +729,8 @@ pub(crate) trait HierarchiesOperations {
 
         ptb.programmable_move_call(
             client.package_id(),
-            ident_str!(move_names::MODULE_MAIN).into(),
-            ident_str!("revoke_property").into(),
+            ident_str!(move_names::MODULE_MAIN).as_str().into(),
+            ident_str!("revoke_property").as_str().into(),
             vec![],
             vec![fed_ref, cap, property_name, clock],
         );
@@ -775,7 +769,7 @@ pub(crate) trait HierarchiesOperations {
 
         let cap = HierarchiesImpl::get_root_authority_cap(client, owner, federation_id).await?;
 
-        let cap = ptb.obj(ObjectArg::ImmOrOwnedObject(cap))?;
+        let cap = ptb.obj(CallArg::ImmutableOrOwned(cap))?;
 
         let fed_ref = HierarchiesImpl::get_fed_ref(client, federation_id).await?;
         let fed_ref = ptb.obj(fed_ref)?;
@@ -787,8 +781,8 @@ pub(crate) trait HierarchiesOperations {
 
         ptb.programmable_move_call(
             client.package_id(),
-            ident_str!(move_names::MODULE_MAIN).into(),
-            ident_str!("revoke_property_at").into(),
+            ident_str!(move_names::MODULE_MAIN).as_str().into(),
+            ident_str!("revoke_property_at").as_str().into(),
             vec![],
             vec![fed_ref, cap, property_name, valid_to_ms, clock],
         );
@@ -838,8 +832,8 @@ pub(crate) trait HierarchiesOperations {
 
         ptb.programmable_move_call(
             client.package_id(),
-            ident_str!(move_names::MODULE_MAIN).into(),
-            ident_str!("validate_property").into(),
+            ident_str!(move_names::MODULE_MAIN).as_str().into(),
+            ident_str!("validate_property").as_str().into(),
             vec![],
             vec![fed_ref, attester_id, property_name, property_value, clock],
         );
@@ -892,19 +886,19 @@ pub(crate) trait HierarchiesOperations {
         let property_name_tag = PropertyName::move_type(client.package_id());
         let property_value_tag = PropertyValue::move_type(client.package_id());
 
-        let property_names_args = ptb.command(Command::MakeMoveVec(
-            Some(property_name_tag.clone().into()),
+        let property_names_args = ptb.command(Command::new_make_move_vector(
+            Some(property_name_tag.clone()),
             property_names,
         ));
-        let property_values_args = ptb.command(Command::MakeMoveVec(
-            Some(property_value_tag.clone().into()),
+        let property_values_args = ptb.command(Command::new_make_move_vector(
+            Some(property_value_tag.clone()),
             property_values,
         ));
 
         let properties = ptb.programmable_move_call(
             client.package_id(),
-            ident_str!("utils").into(),
-            ident_str!("vec_map_from_keys_values").into(),
+            ident_str!("utils").as_str().into(),
+            ident_str!("vec_map_from_keys_values").as_str().into(),
             vec![property_name_tag, property_value_tag],
             vec![property_names_args, property_values_args],
         );
@@ -914,8 +908,8 @@ pub(crate) trait HierarchiesOperations {
 
         ptb.programmable_move_call(
             client.package_id(),
-            ident_str!(move_names::MODULE_MAIN).into(),
-            ident_str!("validate_properties").into(),
+            ident_str!(move_names::MODULE_MAIN).as_str().into(),
+            ident_str!("validate_properties").as_str().into(),
             vec![],
             vec![fed_ref, entity_id, properties, clock],
         );
@@ -937,13 +931,12 @@ pub(crate) trait HierarchiesOperations {
         let mut ptb = ProgrammableTransactionBuilder::new();
 
         let fed_ref = HierarchiesImpl::get_fed_ref(client, federation_id).await?;
-        let fed_ref = CallArg::Object(fed_ref);
         let user_id = CallArg::Pure(bcs::to_bytes(&user_id)?);
 
         ptb.move_call(
             client.package_id(),
-            ident_str!(move_names::MODULE_MAIN).into(),
-            ident_str!("is_root_authority").into(),
+            ident_str!(move_names::MODULE_MAIN).as_str().into(),
+            ident_str!("is_root_authority").as_str().into(),
             vec![],
             vec![fed_ref, user_id],
         )?;
@@ -978,7 +971,7 @@ pub(crate) trait HierarchiesOperations {
 
         let cap = HierarchiesImpl::get_root_authority_cap(client, owner, federation_id).await?;
 
-        let cap = ptb.obj(ObjectArg::ImmOrOwnedObject(cap))?;
+        let cap = ptb.obj(CallArg::ImmutableOrOwned(cap))?;
 
         let fed_ref = HierarchiesImpl::get_fed_ref(client, federation_id).await?;
         let fed_ref = ptb.obj(fed_ref)?;
@@ -987,8 +980,8 @@ pub(crate) trait HierarchiesOperations {
 
         ptb.programmable_move_call(
             client.package_id(),
-            ident_str!(move_names::MODULE_MAIN).into(),
-            ident_str!("revoke_root_authority").into(),
+            ident_str!(move_names::MODULE_MAIN).as_str().into(),
+            ident_str!("revoke_root_authority").as_str().into(),
             vec![],
             vec![fed_ref, cap, account_id_arg],
         );
@@ -1023,7 +1016,7 @@ pub(crate) trait HierarchiesOperations {
         let mut ptb = ProgrammableTransactionBuilder::new();
         let cap = HierarchiesImpl::get_root_authority_cap(client, owner, federation_id).await?;
 
-        let cap = ptb.obj(ObjectArg::ImmOrOwnedObject(cap))?;
+        let cap = ptb.obj(CallArg::ImmutableOrOwned(cap))?;
 
         let fed_ref = HierarchiesImpl::get_fed_ref(client, federation_id).await?;
         let fed_ref = ptb.obj(fed_ref)?;
@@ -1032,8 +1025,8 @@ pub(crate) trait HierarchiesOperations {
 
         ptb.programmable_move_call(
             client.package_id(),
-            ident_str!(move_names::MODULE_MAIN).into(),
-            ident_str!("reinstate_root_authority").into(),
+            ident_str!(move_names::MODULE_MAIN).as_str().into(),
+            ident_str!("reinstate_root_authority").as_str().into(),
             vec![],
             vec![fed_ref, cap, account_id_arg],
         );

--- a/hierarchies-rs/hierarchies/src/core/types/cap.rs
+++ b/hierarchies-rs/hierarchies/src/core/types/cap.rs
@@ -9,8 +9,7 @@
 use std::str::FromStr;
 
 use iota_interaction::MoveType;
-use iota_interaction::types::base_types::TypeTag;
-use iota_interaction::types::base_types::ObjectID;
+use iota_interaction::types::base_types::{ObjectID, TypeTag};
 use iota_interaction::types::id::UID;
 use serde::{Deserialize, Serialize};
 

--- a/hierarchies-rs/hierarchies/src/core/types/cap.rs
+++ b/hierarchies-rs/hierarchies/src/core/types/cap.rs
@@ -9,7 +9,7 @@
 use std::str::FromStr;
 
 use iota_interaction::MoveType;
-use iota_interaction::move_types::language_storage::TypeTag;
+use iota_interaction::types::base_types::TypeTag;
 use iota_interaction::types::base_types::ObjectID;
 use iota_interaction::types::id::UID;
 use serde::{Deserialize, Serialize};

--- a/hierarchies-rs/hierarchies/src/core/types/property.rs
+++ b/hierarchies-rs/hierarchies/src/core/types/property.rs
@@ -4,8 +4,7 @@
 use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 
-use iota_interaction::types::TypeTag;
-use iota_interaction::types::base_types::ObjectID;
+use iota_interaction::types::base_types::{ObjectID, TypeTag};
 use iota_interaction::types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use iota_interaction::types::transaction::{Argument, Command};
 use iota_interaction::{MoveType, ident_str};
@@ -114,8 +113,8 @@ pub(crate) fn new_property(
 
     let property = ptb.programmable_move_call(
         package_id,
-        ident_str!("property").into(),
-        ident_str!("new_property").into(),
+        ident_str!("property").as_str().into(),
+        ident_str!("new_property").as_str().into(),
         vec![],
         vec![property_names, allowed_values, allow_any, shape],
     );
@@ -162,16 +161,16 @@ pub(crate) fn new_properties(
 
         let property = ptb.programmable_move_call(
             package_id,
-            ident_str!("property").into(),
-            ident_str!("new_property").into(),
+            ident_str!("property").as_str().into(),
+            ident_str!("new_property").as_str().into(),
             vec![],
             vec![property_names, allowed_values, allow_any, expression],
         );
         property_args.push(property);
     }
 
-    Ok(ptb.command(Command::MakeMoveVec(
-        Some(FederationProperty::move_type(package_id).into()),
+    Ok(ptb.command(Command::new_make_move_vector(
+        Some(FederationProperty::move_type(package_id)),
         property_args,
     )))
 }

--- a/hierarchies-rs/hierarchies/src/core/types/property_name.rs
+++ b/hierarchies-rs/hierarchies/src/core/types/property_name.rs
@@ -7,8 +7,7 @@
 
 use std::str::FromStr;
 
-use iota_interaction::types::TypeTag;
-use iota_interaction::types::base_types::ObjectID;
+use iota_interaction::types::base_types::{ObjectID, TypeTag};
 use iota_interaction::types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use iota_interaction::types::transaction::Argument;
 use iota_interaction::{MoveType, ident_str};
@@ -67,8 +66,8 @@ pub(crate) fn new_property_name(
     let names = ptb.pure(name.names())?;
     let property_names: Argument = ptb.programmable_move_call(
         package_id,
-        ident_str!("property_name").into(),
-        ident_str!("new_property_name_from_vector").into(),
+        ident_str!("property_name").as_str().into(),
+        ident_str!("new_property_name_from_vector").as_str().into(),
         vec![],
         vec![names],
     );

--- a/hierarchies-rs/hierarchies/src/core/types/property_shape.rs
+++ b/hierarchies-rs/hierarchies/src/core/types/property_shape.rs
@@ -8,8 +8,7 @@
 use std::str::FromStr;
 use std::string::String;
 
-use iota_interaction::types::TypeTag;
-use iota_interaction::types::base_types::ObjectID;
+use iota_interaction::types::base_types::{ObjectID, TypeTag};
 use iota_interaction::types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use iota_interaction::types::transaction::Argument;
 use iota_interaction::{MoveType, ident_str};
@@ -53,8 +52,8 @@ pub(crate) fn new_property_shape_starts_with(
     let text = ptb.pure(text)?;
     let condition = ptb.programmable_move_call(
         package_id,
-        ident_str!("property_shape").into(),
-        ident_str!("new_property_shape_starts_with").into(),
+        ident_str!("property_shape").as_str().into(),
+        ident_str!("new_property_shape_starts_with").as_str().into(),
         vec![],
         vec![text],
     );
@@ -70,8 +69,8 @@ fn new_property_shape_ends_with(
     let text = ptb.pure(text)?;
     let condition = ptb.programmable_move_call(
         package_id,
-        ident_str!("property_shape").into(),
-        ident_str!("new_property_shape_ends_with").into(),
+        ident_str!("property_shape").as_str().into(),
+        ident_str!("new_property_shape_ends_with").as_str().into(),
         vec![],
         vec![text],
     );
@@ -87,8 +86,8 @@ fn new_property_shape_contains(
     let text = ptb.pure(text)?;
     let condition = ptb.programmable_move_call(
         package_id,
-        ident_str!("property_shape").into(),
-        ident_str!("new_property_shape_contains").into(),
+        ident_str!("property_shape").as_str().into(),
+        ident_str!("new_property_shape_contains").as_str().into(),
         vec![],
         vec![text],
     );
@@ -104,8 +103,8 @@ fn new_property_shape_greater_than(
     let value = ptb.pure(value)?;
     let condition = ptb.programmable_move_call(
         package_id,
-        ident_str!("property_shape").into(),
-        ident_str!("new_property_shape_greater_than").into(),
+        ident_str!("property_shape").as_str().into(),
+        ident_str!("new_property_shape_greater_than").as_str().into(),
         vec![],
         vec![value],
     );
@@ -120,8 +119,8 @@ fn new_property_shape_lower_than(
     let value = ptb.pure(value)?;
     let condition = ptb.programmable_move_call(
         package_id,
-        ident_str!("property_shape").into(),
-        ident_str!("new_property_shape_lower_than").into(),
+        ident_str!("property_shape").as_str().into(),
+        ident_str!("new_property_shape_lower_than").as_str().into(),
         vec![],
         vec![value],
     );

--- a/hierarchies-rs/hierarchies/src/core/types/property_value.rs
+++ b/hierarchies-rs/hierarchies/src/core/types/property_value.rs
@@ -3,8 +3,7 @@
 
 use std::str::FromStr;
 
-use iota_interaction::types::TypeTag;
-use iota_interaction::types::base_types::ObjectID;
+use iota_interaction::types::base_types::{ObjectID, TypeTag};
 use iota_interaction::types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use iota_interaction::types::transaction::Argument;
 use iota_interaction::{MoveType, ident_str};
@@ -41,8 +40,8 @@ pub(crate) fn new_property_value_string(
     let v = ptb.pure(value)?;
     Ok(ptb.programmable_move_call(
         package_id,
-        ident_str!("property_value").into(),
-        ident_str!("new_property_value_string").into(),
+        ident_str!("property_value").as_str().into(),
+        ident_str!("new_property_value_string").as_str().into(),
         vec![],
         vec![v],
     ))
@@ -57,8 +56,8 @@ pub(crate) fn new_property_value_number(
     let v = ptb.pure(value)?;
     Ok(ptb.programmable_move_call(
         package_id,
-        ident_str!("property_value").into(),
-        ident_str!("new_property_value_number").into(),
+        ident_str!("property_value").as_str().into(),
+        ident_str!("new_property_value_number").as_str().into(),
         vec![],
         vec![v],
     ))

--- a/hierarchies-rs/hierarchies/src/utils.rs
+++ b/hierarchies-rs/hierarchies/src/utils.rs
@@ -6,11 +6,11 @@ use std::fmt::Debug;
 use std::hash::Hash;
 
 use iota_interaction::ident_str;
-use iota_interaction::types::base_types::{ObjectID, STD_OPTION_MODULE_NAME};
+use iota_interaction::types::MOVE_STDLIB_PACKAGE_ID;
+use iota_interaction::types::base_types::{ObjectID, TypeTag};
 use iota_interaction::types::collection_types::{VecMap, VecSet};
 use iota_interaction::types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use iota_interaction::types::transaction::{Argument, Command};
-use iota_interaction::types::{MOVE_STDLIB_PACKAGE_ID, TypeTag};
 use serde::{Deserialize, Deserializer};
 
 /// Deserialize a [`VecMap`] into a [`HashMap`]
@@ -47,16 +47,16 @@ pub(crate) fn option_to_move(
     let arg = if let Some(t) = option {
         ptb.programmable_move_call(
             MOVE_STDLIB_PACKAGE_ID,
-            STD_OPTION_MODULE_NAME.into(),
-            ident_str!("some").into(),
+            ident_str!("option").as_str().into(),
+            ident_str!("some").as_str().into(),
             vec![tag],
             vec![t],
         )
     } else {
         ptb.programmable_move_call(
             MOVE_STDLIB_PACKAGE_ID,
-            STD_OPTION_MODULE_NAME.into(),
-            ident_str!("none").into(),
+            ident_str!("option").as_str().into(),
+            ident_str!("none").as_str().into(),
             vec![tag],
             vec![],
         )
@@ -72,12 +72,12 @@ pub(crate) fn create_vec_set_from_move_values(
     ptb: &mut ProgrammableTransactionBuilder,
     package_id: ObjectID,
 ) -> Argument {
-    let values = ptb.command(Command::MakeMoveVec(Some(tag.clone().into()), values));
+    let values = ptb.command(Command::new_make_move_vector(Some(tag.clone()), values));
 
     ptb.programmable_move_call(
         package_id,
-        ident_str!("utils").into(),
-        ident_str!("create_vec_set").into(),
+        ident_str!("utils").as_str().into(),
+        ident_str!("create_vec_set").as_str().into(),
         vec![tag],
         vec![values],
     )

--- a/hierarchies-rs/hierarchies/tests/e2e/test_authority.rs
+++ b/hierarchies-rs/hierarchies/tests/e2e/test_authority.rs
@@ -62,7 +62,7 @@ async fn test_revoke_root_authority_success() -> anyhow::Result<()> {
         .await?;
 
     // Verify all three are root authorities
-    let alice_id = ObjectID::from_address(client.sender_address().into());
+    let alice_id = ObjectID::from_address(client.sender_address());
     assert!(client.is_root_authority(*federation.object_id(), alice_id).await?);
     assert!(client.is_root_authority(*federation.object_id(), bob_id).await?);
     assert!(client.is_root_authority(*federation.object_id(), charlie_id).await?);
@@ -123,7 +123,7 @@ async fn test_cannot_revoke_last_root_authority() -> anyhow::Result<()> {
         .output
         .id;
 
-    let alice_id = ObjectID::from_address(client.sender_address().into());
+    let alice_id = ObjectID::from_address(client.sender_address());
 
     // Try to revoke the only root authority (Alice)
     let result = client
@@ -152,7 +152,7 @@ async fn test_is_root_authority() -> anyhow::Result<()> {
         .output
         .id;
 
-    let alice_id = ObjectID::from_address(client.sender_address().into());
+    let alice_id = ObjectID::from_address(client.sender_address());
     let bob_id = ObjectID::random();
     let charlie_id = ObjectID::random();
 


### PR DESCRIPTION
# Description of change

Following dependencies have been changed:
- [x] tokio version update to: 1.52.2
- [ ] fastcrypto version update to rev = "-"
- [x] hierarchies_wasm: new peerDep. version for @iota/iota-sdk: `"^1.14.0"`
- [ ] hierarchies_wasm: new dependency version for @iota/iota-interaction-ts: _
- [x] pin all product-core.git dependencies to `tag = 0.8.18`
- [x] pin all iota.git dependencies to `tag = "v1.23.2"`

IOTA 1.23.2 replaced several base-types formerly implemented in iota.git with types from the standalone Rust SDK (iota-rust-sdk.git). This caused several migrations in hierarchies_wasm and hierarchies_rs.

Summary of main changes:
  - `ident_str!(...).into()` occurrences:
    append `.as_str()` so the conversion goes via `From<&'static str>` for Identifier instead of the now-removed From<&IdentStr>.
  - Owner variant renamings: 
    - `AddressOwner`→ `Address`
    - `ObjectOwner` → `Object` (now carries `ObjectId`, dereffed via `as_address()`)
    - `Shared { .. }` → `Shared(_)`
    - add a catch-all arm since Owner is `#[non_exhaustive]`
  - `IotaAddress::random_for_testing_only()` → `IotaAddress::random()`
  - `TransactionKind::programmable(tx)` → `TransactionKind::Programmable(tx)`
  - `ObjectArg::SharedObject{...}` → `CallArg::Shared(SharedObjectRef {...})`
  - `ObjectArg::ImmOrOwnedObject(...)` → `CallArg::ImmutableOrOwned(...)`
  - `use iota_interaction::types::TypeTag` → `use iota_interaction::types::base_types::TypeTag`


## Links to any relevant issues
https://github.com/iotaledger/product-core/issues/67