### PR TITLE
fix: federation object representation in TS

### DIFF
--- a/bindings/wasm/hierarchies_wasm/examples/src/tests.ts
+++ b/bindings/wasm/hierarchies_wasm/examples/src/tests.ts
@@ -18,6 +18,7 @@ import { supplyChain } from "./real-world/02_supply_chain";
 import { getAccreditations } from "./validation/01_get_accreditations";
 import { validateProperties } from "./validation/02_validate_properties";
 import { getProperties } from "./validation/03_get_properties";
+import { federationSerialization } from "./validation/04_federation_serialization";
 
 import { afterEach } from "mocha";
 
@@ -63,6 +64,9 @@ describe("Test node examples", function() {
     });
     it("Should get Properties", async () => {
         await getProperties();
+    });
+    it("Should expose consistent serialization from getFederationById", async () => {
+        await federationSerialization();
     });
     it("Should run University Degrees Example", async () => {
         await universityDegrees();

--- a/bindings/wasm/hierarchies_wasm/examples/src/validation/04_federation_serialization.ts
+++ b/bindings/wasm/hierarchies_wasm/examples/src/validation/04_federation_serialization.ts
@@ -1,0 +1,105 @@
+// Copyright 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+    Accreditations,
+    Federation,
+    FederationProperty,
+    PropertyName,
+    PropertyShape,
+    PropertyValue,
+} from "@iota/hierarchies/node";
+import { strict as assert } from "assert";
+import { generateRandomAddress, getFundedClient } from "../util";
+
+/**
+ * Regression test for the `getFederationById` serialization inconsistency.
+ *
+ * Previously the `governance.accreditationsToAttest` /
+ * `accreditationsToAccredit` Map values were produced via
+ * `serde_wasm_bindgen::to_value`, which bypassed the `wasm_bindgen` getters and
+ * leaked raw Rust field names (`accredited_by`, `allow_any`, `valid_from_ms`,
+ * …). This asserts the Map values now expose the same camelCase getters as the
+ * rest of the response, and that the inner property wrappers surface their data
+ * (instead of rendering as `{}`).
+ */
+export async function federationSerialization(): Promise<void> {
+    const hierarchies = await getFundedClient();
+    const { output: federation }: { output: Federation } = await hierarchies.createNewFederation().buildAndExecute(
+        hierarchies,
+    );
+    console.log("\n✅ Federation created successfully!");
+    console.log("Federation ID: ", federation.id);
+
+    const propertyName = new PropertyName(["test", "property"]);
+
+    await hierarchies.addProperty(
+        federation.id,
+        new FederationProperty(propertyName).withAllowedValues([PropertyValue.newText("foo")]),
+    ).buildAndExecute(hierarchies);
+    console.log(`\n✅ Property ${propertyName.dotted()} added successfully`);
+
+    const receiver = generateRandomAddress();
+    const propertyToAttest = new FederationProperty(propertyName)
+        .withAllowedValues([PropertyValue.newText("foo")])
+        .withCondition(PropertyShape.newContains("foo"));
+
+    await hierarchies.createAccreditationToAttest(federation.id, receiver, [propertyToAttest])
+        .buildAndExecute(hierarchies);
+    console.log(`\n✅ Accreditation to attest created for ${receiver}`);
+
+    // Fetch the whole federation — this is the path that used to mix casing.
+    const fetched: Federation = await hierarchies.readOnly().getFederationById(federation.id);
+
+    const attestMap = fetched.governance.accreditationsToAttest;
+    assert(attestMap.size > 0, "Expected at least one accreditationsToAttest entry");
+
+    // The Map value must be a real `Accreditations` wrapper, not a serde dump.
+    const accreditations = [...attestMap.values()][0] as Accreditations;
+    assert(accreditations.accreditations.length > 0, "Expected at least one accreditation");
+
+    const accreditation = accreditations.accreditations[0];
+
+    // (A) camelCase getters must work — raw snake_case must NOT be present.
+    assert.equal(typeof accreditation.accreditedBy, "string", "accreditedBy getter should return a string");
+    assert.equal(
+        (accreditation as unknown as Record<string, unknown>).accredited_by,
+        undefined,
+        "snake_case `accredited_by` must not leak through the Map path",
+    );
+
+    // properties is an Array<FederationProperty>, matching governance.properties.data.
+    assert(Array.isArray(accreditation.properties), "properties should be an array");
+    assert(accreditation.properties.length > 0, "Expected at least one property");
+    const property = accreditation.properties[0];
+
+    assert.equal(typeof property.allowAny, "boolean", "allowAny getter should return a boolean");
+    assert.equal(
+        (property as unknown as Record<string, unknown>).allow_any,
+        undefined,
+        "snake_case `allow_any` must not leak",
+    );
+
+    // timespan getters are camelCase (validFromMs / validUntilMs).
+    assert(property.timespan !== undefined, "timespan should be present");
+    assert.equal(
+        (property.timespan as unknown as Record<string, unknown>).valid_from_ms,
+        undefined,
+        "snake_case `valid_from_ms` must not leak",
+    );
+
+    // (B) inner wrappers must surface their data, not render as `{}`.
+    assert(property.propertyName.getNames().length > 0, "propertyName should expose its names");
+    assert.equal(property.propertyName.dotted(), propertyName.dotted(), "propertyName should match");
+
+    const condition = property.condition;
+    assert(condition !== undefined, "condition (shape) should be present");
+    assert.equal(condition!.asContains(), "foo", "condition should expose its Contains value");
+
+    // The new `type`/`value` getters and `names` getter make the data
+    // enumerable, so JSON.stringify no longer hides it behind `{}`.
+    const json = JSON.parse(JSON.stringify(accreditation));
+    assert(!("accredited_by" in json), "serialized accreditation must not contain snake_case keys");
+
+    console.log("✅ getFederationById accreditations expose consistent camelCase getters and visible inner data");
+}

--- a/bindings/wasm/hierarchies_wasm/src/wasm_types/federation.rs
+++ b/bindings/wasm/hierarchies_wasm/src/wasm_types/federation.rs
@@ -107,7 +107,7 @@ impl WasmGovernance {
         for (key, value) in &self.0.accreditations_to_accredit {
             map.set(
                 &wasm_bindgen::JsValue::from_str(&key.to_string()),
-                &serde_wasm_bindgen::to_value(&WasmAccreditations::from(value.clone())).unwrap(),
+                &wasm_bindgen::JsValue::from(WasmAccreditations::from(value.clone())),
             );
         }
         map
@@ -123,7 +123,7 @@ impl WasmGovernance {
         for (key, value) in &self.0.accreditations_to_attest {
             map.set(
                 &wasm_bindgen::JsValue::from_str(&key.to_string()),
-                &serde_wasm_bindgen::to_value(&WasmAccreditations::from(value.clone())).unwrap(),
+                &wasm_bindgen::JsValue::from(WasmAccreditations::from(value.clone())),
             );
         }
         map

--- a/bindings/wasm/hierarchies_wasm/src/wasm_types/property_name.rs
+++ b/bindings/wasm/hierarchies_wasm/src/wasm_types/property_name.rs
@@ -22,6 +22,12 @@ impl WasmPropertyName {
         Self(PropertyName::new(names))
     }
 
+    /// Returns the property names as an enumerable `names` property.
+    #[wasm_bindgen(getter, js_name = names, unchecked_return_type = "Array<String>")]
+    pub fn names(&self) -> js_sys::Array {
+        self.0.names().iter().map(JsValue::from).collect()
+    }
+
     /// Returns the property names as
     #[wasm_bindgen(js_name = getNames, unchecked_return_type = "Array<String>")]
     pub fn get_names(&self) -> js_sys::Array {

--- a/bindings/wasm/hierarchies_wasm/src/wasm_types/property_shape.rs
+++ b/bindings/wasm/hierarchies_wasm/src/wasm_types/property_shape.rs
@@ -41,6 +41,36 @@ impl WasmPropertyShape {
         Self(PropertyShape::LowerThan(value))
     }
 
+    /// Returns the variant tag (`"StartsWith"`, `"EndsWith"`, `"Contains"`,
+    /// `"GreaterThan"` or `"LowerThan"`).
+    ///
+    /// Exposed as a `#[wasm_bindgen(getter)]` together with [`Self::value`] so
+    /// the contained data is visible under `console.log` / `JSON.stringify`
+    /// (an `inspectable` class with only methods renders as `{}`).
+    #[wasm_bindgen(getter, js_name = "type")]
+    pub fn variant_type(&self) -> String {
+        match self.0 {
+            PropertyShape::StartsWith(_) => "StartsWith".to_string(),
+            PropertyShape::EndsWith(_) => "EndsWith".to_string(),
+            PropertyShape::Contains(_) => "Contains".to_string(),
+            PropertyShape::GreaterThan(_) => "GreaterThan".to_string(),
+            PropertyShape::LowerThan(_) => "LowerThan".to_string(),
+        }
+    }
+
+    /// Returns the contained value as a `string` (for the text variants) or a
+    /// `number` (for `GreaterThan` / `LowerThan`). Pairs with
+    /// [`Self::variant_type`] for inspection.
+    #[wasm_bindgen(getter)]
+    pub fn value(&self) -> JsValue {
+        match &self.0 {
+            PropertyShape::StartsWith(text) | PropertyShape::EndsWith(text) | PropertyShape::Contains(text) => {
+                JsValue::from_str(text)
+            }
+            PropertyShape::GreaterThan(value) | PropertyShape::LowerThan(value) => JsValue::from_f64(*value as f64),
+        }
+    }
+
     /// Returns `true` if the `PropertyShape` is of type `StartsWith`.
     #[wasm_bindgen(js_name = isStartsWith)]
     pub fn is_starts_with(&self) -> bool {

--- a/bindings/wasm/hierarchies_wasm/src/wasm_types/property_value.rs
+++ b/bindings/wasm/hierarchies_wasm/src/wasm_types/property_value.rs
@@ -33,6 +33,25 @@ impl WasmPropertyValue {
         Self(PropertyValue::Number(number))
     }
 
+    /// Returns the variant tag (`"Text"` or `"Number"`).
+    #[wasm_bindgen(getter, js_name = "type")]
+    pub fn variant_type(&self) -> String {
+        match self.0 {
+            PropertyValue::Text(_) => "Text".to_string(),
+            PropertyValue::Number(_) => "Number".to_string(),
+        }
+    }
+
+    /// Returns the contained value as a `string` (for `Text`) or a `number`
+    /// (for `Number`). Pairs with [`Self::variant_type`] for inspection.
+    #[wasm_bindgen(getter)]
+    pub fn value(&self) -> JsValue {
+        match &self.0 {
+            PropertyValue::Text(text) => JsValue::from_str(text),
+            PropertyValue::Number(number) => JsValue::from_f64(*number as f64),
+        }
+    }
+
     /// Returns `true` if the `PropertyValue` is of type `Text`.
     #[wasm_bindgen(js_name = isText)]
     pub fn is_text(&self) -> bool {


### PR DESCRIPTION
# Description

`WasmHierarchiesClientReadOnly.getFederationById()` returned an object that mixed
two serialization conventions: the `governance.accreditationsToAccredit` /
`accreditationsToAttest` Map values were produced via
`serde_wasm_bindgen::to_value`, which bypassed the `wasm_bindgen` getters and
leaked raw Rust field names (snake_case), while the rest of the response used
camelCase getters. Inner property wrappers (`PropertyName` / `PropertyShape` /
`PropertyValue`) also rendered as `{}` under `console.log` / `JSON.stringify`.

## Changes (Wasm bindings only — Move and Rust core untouched)

- Route the two `Governance` Map getters through
  `JsValue::from(WasmAccreditations::from(...))` instead of serde, so the values
  surface the same camelCase getters as the rest of the federation.
- Add enumerable getters so inner wrappers no longer inspect as `{}`: `names` on
  `PropertyName`, and `type` + `value` on `PropertyShape` / `PropertyValue`
  (existing `is*` / `as*` / `getNames` / `dotted` methods unchanged).
- Add regression test `validation/04_federation_serialization.ts` (wired into
  `tests.ts`). Full `npm run test:node` suite passes (15/15) against a localnet.

## ⚠️ Breaking changes

Affects **only** consumers of
`getFederationById().governance.accreditationsToAccredit` /
`accreditationsToAttest` Map values:

|                                 | Before                                       | After                                          |
| ------------------------------- | -------------------------------------------- | ---------------------------------------------- |
| field casing                    | `accredited_by`, `allow_any`, `valid_from_ms` | `accreditedBy`, `allowAny`, `timespan.validFromMs` |
| `accreditations[i].properties`  | object keyed by `{ names: [...] }`           | `Array<FederationProperty>`                    |
| Map value type                  | plain serde object                           | `Accreditations` class instance                |

Migrate by reading the camelCase getters and iterating `properties` as an array.
This now matches the shape already returned by `getAccreditationsToAttest()` /
`getAccreditationsToAccredit()`, so the two paths are finally consistent.

**Non-breaking:** the new `names` / `type` / `value` getters are purely additive.


closes #182 