### PR TITLE
fix: enable federation level shapes

### DIFF
--- a/bindings/wasm/hierarchies_wasm/examples/src/out_of_scope.ts
+++ b/bindings/wasm/hierarchies_wasm/examples/src/out_of_scope.ts
@@ -1,0 +1,50 @@
+// Copyright 2020-2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import { Federation, FederationProperty, HierarchiesClient, PropertyName, PropertyValue } from "@iota/hierarchies/node";
+import { strict as assert } from "assert";
+import { generateRandomAddress, getFundedClient } from "./util";
+
+/**
+ * Regression test for the federation value-scope gate.
+ *
+ * A federation property declares a bounded value space (`allowed_values = {"a"}`).
+ * Issuing an accreditation for a value outside that space (`"b"`) must be
+ * rejected on-chain (EPropertyValuesOutOfFederationScope), even though the
+ * caller is a root authority.
+ */
+export async function createAccreditationOutOfScopeFails(client?: HierarchiesClient) {
+    console.log("\nRunning out-of-scope accreditation rejection test");
+
+    const hierarchies = client ?? (await getFundedClient());
+
+    // Create a new federation.
+    const { output: federation }: { output: Federation } = await hierarchies.createNewFederation().buildAndExecute(
+        hierarchies,
+    );
+    console.log("Federation ID: ", federation.id);
+
+    // Federation declares test-property with allowed_values = {"a"}.
+    const propertyName = new PropertyName(["test-property"]);
+    await hierarchies
+        .addProperty(
+            federation.id,
+            new FederationProperty(propertyName).withAllowedValues([PropertyValue.newText("a")]),
+        )
+        .buildAndExecute(hierarchies);
+
+    const receiver = generateRandomAddress();
+
+    // Request an accreditation for "b", which is outside the federation's value space.
+    const outOfScope = new FederationProperty(propertyName).withAllowedValues([PropertyValue.newText("b")]);
+
+    // The transaction must be rejected.
+    await assert.rejects(
+        hierarchies
+            .createAccreditationToAttest(federation.id, receiver, [outOfScope])
+            .buildAndExecute(hierarchies),
+        "out-of-scope accreditation should be rejected on-chain",
+    );
+
+    console.log("\n✅ Out-of-scope accreditation correctly rejected");
+}

--- a/bindings/wasm/hierarchies_wasm/examples/src/real-world/01_university_degrees.ts
+++ b/bindings/wasm/hierarchies_wasm/examples/src/real-world/01_university_degrees.ts
@@ -46,7 +46,14 @@
  * - Alumni verification for networking platforms
  */
 
-import { Accreditation, Federation, FederationProperty, PropertyName, PropertyValue } from "@iota/hierarchies/node";
+import {
+    Accreditation,
+    Federation,
+    FederationProperty,
+    PropertyName,
+    PropertyShape,
+    PropertyValue,
+} from "@iota/hierarchies/node";
 import { getFundedClient } from "../util";
 
 /**
@@ -345,15 +352,17 @@ export async function universityDegreesExample(): Promise<void> {
     await hierarchies
         .addProperty(
             universityConsortium.id,
-            new FederationProperty(gradeGpa).withAllowedValues([
-                PropertyValue.newNumber(200n),
-                PropertyValue.newNumber(250n),
-                PropertyValue.newNumber(300n),
-                PropertyValue.newNumber(320n),
-                PropertyValue.newNumber(350n),
-                PropertyValue.newNumber(380n),
-                PropertyValue.newNumber(400n),
-            ]),
+            new FederationProperty(gradeGpa)
+                .withCondition(PropertyShape.newGreaterThan(200n)) // GPA > 2.0 (stored as 200 for precision)
+                .withAllowedValues([
+                    PropertyValue.newNumber(200n),
+                    PropertyValue.newNumber(250n),
+                    PropertyValue.newNumber(300n),
+                    PropertyValue.newNumber(320n),
+                    PropertyValue.newNumber(350n),
+                    PropertyValue.newNumber(380n),
+                    PropertyValue.newNumber(400n),
+                ]),
         )
         .buildAndExecute(hierarchies);
 
@@ -361,20 +370,22 @@ export async function universityDegreesExample(): Promise<void> {
     await hierarchies
         .addProperty(
             universityConsortium.id,
-            new FederationProperty(graduationYear).withAllowedValues([
-                PropertyValue.newNumber(1950n),
-                PropertyValue.newNumber(1960n),
-                PropertyValue.newNumber(1970n),
-                PropertyValue.newNumber(1980n),
-                PropertyValue.newNumber(1990n),
-                PropertyValue.newNumber(2000n),
-                PropertyValue.newNumber(2010n),
-                PropertyValue.newNumber(2020n),
-                PropertyValue.newNumber(2021n),
-                PropertyValue.newNumber(2022n),
-                PropertyValue.newNumber(2023n),
-                PropertyValue.newNumber(2024n),
-            ]),
+            new FederationProperty(graduationYear)
+                .withCondition(PropertyShape.newGreaterThan(1950n))
+                .withAllowedValues([
+                    PropertyValue.newNumber(1950n),
+                    PropertyValue.newNumber(1960n),
+                    PropertyValue.newNumber(1970n),
+                    PropertyValue.newNumber(1980n),
+                    PropertyValue.newNumber(1990n),
+                    PropertyValue.newNumber(2000n),
+                    PropertyValue.newNumber(2010n),
+                    PropertyValue.newNumber(2020n),
+                    PropertyValue.newNumber(2021n),
+                    PropertyValue.newNumber(2022n),
+                    PropertyValue.newNumber(2023n),
+                    PropertyValue.newNumber(2024n),
+                ]),
         )
         .buildAndExecute(hierarchies);
 
@@ -448,19 +459,38 @@ export async function universityDegreesExample(): Promise<void> {
     // Simulate Harvard CS Faculty address
     const harvardCsFaculty = "0x" + Math.random().toString(16).substring(2, 42).padStart(40, "0");
 
-    // Harvard delegates accreditation rights to its CS Faculty
-    // This allows the faculty to further delegate to registrars and professors
+    // Harvard delegates accreditation rights to its CS Faculty.
+    // This allows the faculty to further delegate to registrars and professors.
+    // The delegated value space must stay within the federation's declared
+    // bounds for each property, so we delegate the federation's full set of
+    // allowed values rather than `allowAny`.
+    //
+    // Note: `PropertyValue`/`FederationProperty` instances are consumed when
+    // passed across the wasm boundary, so these are factory functions that
+    // produce fresh instances for each transaction.
+    const degreeValues = () => [
+        PropertyValue.newText("completed"),
+        PropertyValue.newText("in_progress"),
+        PropertyValue.newText("withdrawn"),
+    ];
+    const booleanValues = () => [PropertyValue.newText("true"), PropertyValue.newText("false")];
+    const gpaValues = () => [200n, 250n, 300n, 320n, 350n, 380n, 400n].map(n => PropertyValue.newNumber(n));
+    const graduationYearValues = () =>
+        [1950n, 1960n, 1970n, 1980n, 1990n, 2000n, 2010n, 2020n, 2021n, 2022n, 2023n, 2024n]
+            .map(n => PropertyValue.newNumber(n));
+
+    const csFacultyProperties = () => [
+        new FederationProperty(degreeBachelor).withAllowedValues(degreeValues()),
+        new FederationProperty(degreeMaster).withAllowedValues(degreeValues()),
+        new FederationProperty(degreePhd).withAllowedValues(degreeValues()),
+        new FederationProperty(fieldCs).withAllowedValues(booleanValues()),
+        new FederationProperty(gradeGpa).withAllowedValues(gpaValues()),
+        new FederationProperty(graduationYear).withAllowedValues(graduationYearValues()),
+        new FederationProperty(studentVerified).withAllowedValues(booleanValues()),
+    ];
 
     await hierarchies
-        .createAccreditationToAccredit(universityConsortium.id, harvardCsFaculty, [
-            new FederationProperty(degreeBachelor).withAllowAny(true),
-            new FederationProperty(degreeMaster).withAllowAny(true),
-            new FederationProperty(degreePhd).withAllowAny(true),
-            new FederationProperty(fieldCs).withAllowAny(true),
-            new FederationProperty(gradeGpa).withAllowAny(true),
-            new FederationProperty(graduationYear).withAllowAny(true),
-            new FederationProperty(studentVerified).withAllowAny(true),
-        ])
+        .createAccreditationToAccredit(universityConsortium.id, harvardCsFaculty, csFacultyProperties())
         .buildAndExecute(hierarchies);
 
     console.log("✅ Harvard CS Faculty granted accreditation rights:");
@@ -478,15 +508,7 @@ export async function universityDegreesExample(): Promise<void> {
     // CS Faculty delegates attestation rights to the CS Registrar
     // Registrar can now create attestations (issue degrees) but not delegate further
     await hierarchies
-        .createAccreditationToAttest(universityConsortium.id, harvardCsRegistrar, [
-            new FederationProperty(degreeBachelor).withAllowAny(true),
-            new FederationProperty(degreeMaster).withAllowAny(true),
-            new FederationProperty(degreePhd).withAllowAny(true),
-            new FederationProperty(fieldCs).withAllowAny(true),
-            new FederationProperty(gradeGpa).withAllowAny(true),
-            new FederationProperty(graduationYear).withAllowAny(true),
-            new FederationProperty(studentVerified).withAllowAny(true),
-        ])
+        .createAccreditationToAttest(universityConsortium.id, harvardCsRegistrar, csFacultyProperties())
         .buildAndExecute(hierarchies);
 
     console.log("✅ Harvard CS Registrar granted attestation rights:");

--- a/bindings/wasm/hierarchies_wasm/examples/src/real-world/02_supply_chain.ts
+++ b/bindings/wasm/hierarchies_wasm/examples/src/real-world/02_supply_chain.ts
@@ -375,18 +375,39 @@ export async function supplyChainExample(): Promise<void> {
     // German Testing Institute under ISO Europe
     const germanTestingInstitute = "0x" + Math.random().toString(16).substring(2, 42).padStart(40, "0");
 
-    // Create comprehensive accreditation package for German institute
+    // The delegated value space must stay within the federation's declared
+    // bounds for each property, so we delegate the federation's declared sets
+    // rather than `allowAny`. Only `originVerified` and `expiryDate` are
+    // declared `allowAny` by the federation, so they may be delegated as such.
+    //
+    // Note: `PropertyValue`/`FederationProperty` instances are consumed when
+    // passed across the wasm boundary, so these are factory functions that
+    // produce fresh instances for each property.
+    const certStatusValues = () => [
+        PropertyValue.newText("certified"),
+        PropertyValue.newText("pending"),
+        PropertyValue.newText("expired"),
+        PropertyValue.newText("revoked"),
+        PropertyValue.newText("suspended"),
+    ];
+    const booleanValues = () => [PropertyValue.newText("true"), PropertyValue.newText("false")];
+    const testResults = () => [
+        PropertyValue.newText("passed"),
+        PropertyValue.newText("failed"),
+        PropertyValue.newText("pending"),
+        PropertyValue.newText("inconclusive"),
+    ];
 
     // ISO Europe delegates accreditation rights to German Testing Institute
     await hierarchies
         .createAccreditationToAccredit(standardsConsortium.id, germanTestingInstitute, [
-            new FederationProperty(iso9001).withAllowAny(true),
-            new FederationProperty(iso14001).withAllowAny(true),
-            new FederationProperty(iso22000).withAllowAny(true),
-            new FederationProperty(productOrganic).withAllowAny(true),
+            new FederationProperty(iso9001).withAllowedValues(certStatusValues()),
+            new FederationProperty(iso14001).withAllowedValues(certStatusValues()),
+            new FederationProperty(iso22000).withAllowedValues(certStatusValues()),
+            new FederationProperty(productOrganic).withAllowedValues(booleanValues()),
             new FederationProperty(originVerified).withAllowAny(true),
-            new FederationProperty(batchTested).withAllowAny(true),
-            new FederationProperty(complianceEu).withAllowAny(true),
+            new FederationProperty(batchTested).withAllowedValues(testResults()),
+            new FederationProperty(complianceEu).withAllowedValues(booleanValues()),
             new FederationProperty(expiryDate).withAllowAny(true),
         ])
         .buildAndExecute(hierarchies);
@@ -396,12 +417,12 @@ export async function supplyChainExample(): Promise<void> {
 
     await hierarchies
         .createAccreditationToAccredit(standardsConsortium.id, usFdaRegional, [
-            new FederationProperty(iso9001).withAllowAny(true),
-            new FederationProperty(iso22000).withAllowAny(true),
-            new FederationProperty(productOrganic).withAllowAny(true),
+            new FederationProperty(iso9001).withAllowedValues(certStatusValues()),
+            new FederationProperty(iso22000).withAllowedValues(certStatusValues()),
+            new FederationProperty(productOrganic).withAllowedValues(booleanValues()),
             new FederationProperty(originVerified).withAllowAny(true),
-            new FederationProperty(batchTested).withAllowAny(true),
-            new FederationProperty(complianceFda).withAllowAny(true),
+            new FederationProperty(batchTested).withAllowedValues(testResults()),
+            new FederationProperty(complianceFda).withAllowedValues(booleanValues()),
             new FederationProperty(expiryDate).withAllowAny(true),
         ])
         .buildAndExecute(hierarchies);
@@ -425,11 +446,11 @@ export async function supplyChainExample(): Promise<void> {
     // German Testing Institute delegates attestation rights to Berlin lab
     await hierarchies
         .createAccreditationToAttest(standardsConsortium.id, berlinFoodLab, [
-            new FederationProperty(iso22000).withAllowAny(true),
-            new FederationProperty(productOrganic).withAllowAny(true),
+            new FederationProperty(iso22000).withAllowedValues(certStatusValues()),
+            new FederationProperty(productOrganic).withAllowedValues(booleanValues()),
             new FederationProperty(originVerified).withAllowAny(true),
-            new FederationProperty(batchTested).withAllowAny(true),
-            new FederationProperty(complianceEu).withAllowAny(true),
+            new FederationProperty(batchTested).withAllowedValues(testResults()),
+            new FederationProperty(complianceEu).withAllowedValues(booleanValues()),
             new FederationProperty(expiryDate).withAllowAny(true),
         ])
         .buildAndExecute(hierarchies);
@@ -439,12 +460,12 @@ export async function supplyChainExample(): Promise<void> {
 
     await hierarchies
         .createAccreditationToAttest(standardsConsortium.id, californiaAgLab, [
-            new FederationProperty(iso9001).withAllowAny(true),
-            new FederationProperty(iso22000).withAllowAny(true),
-            new FederationProperty(productOrganic).withAllowAny(true),
+            new FederationProperty(iso9001).withAllowedValues(certStatusValues()),
+            new FederationProperty(iso22000).withAllowedValues(certStatusValues()),
+            new FederationProperty(productOrganic).withAllowedValues(booleanValues()),
             new FederationProperty(originVerified).withAllowAny(true),
-            new FederationProperty(batchTested).withAllowAny(true),
-            new FederationProperty(complianceFda).withAllowAny(true),
+            new FederationProperty(batchTested).withAllowedValues(testResults()),
+            new FederationProperty(complianceFda).withAllowedValues(booleanValues()),
             new FederationProperty(expiryDate).withAllowAny(true),
         ])
         .buildAndExecute(hierarchies);

--- a/bindings/wasm/hierarchies_wasm/examples/src/tests.ts
+++ b/bindings/wasm/hierarchies_wasm/examples/src/tests.ts
@@ -13,6 +13,7 @@ import { createAccreditationToAccredit } from "./06_create_accreditation_to_accr
 import { revokeAccreditationToAccredit } from "./07_revoke_accreditation_to_accredit";
 import { revokeRootAuthority } from "./08_revoke_root_authority";
 import { reinstateRootAuthority } from "./09_reinstate_root_authority";
+import { createAccreditationOutOfScopeFails } from "./out_of_scope";
 import { universityDegrees } from "./real-world/01_university_degrees";
 import { supplyChain } from "./real-world/02_supply_chain";
 import { getAccreditations } from "./validation/01_get_accreditations";
@@ -39,6 +40,9 @@ describe("Test node examples", function() {
     });
     it("Should create Accreditation to Attest", async () => {
         await createAccreditationToAttest();
+    });
+    it("Should reject out-of-scope Accreditation", async () => {
+        await createAccreditationOutOfScopeFails();
     });
     it("Should revoke Accreditation to Attest", async () => {
         await revokeAccreditationToAttest();

--- a/hierarchies-move/sources/hierarchies.move
+++ b/hierarchies-move/sources/hierarchies.move
@@ -37,6 +37,9 @@ const EAlreadyRootAuthority: u64 = 11;
 const ENotRevokedRootAuthority: u64 = 12;
 /// Error when trying to create accreditation for a revoked property
 const EPropertyRevoked: u64 = 13;
+/// Error when a requested accreditation's value space is not a subset of the
+/// federation's declared value space for that property
+const EPropertyValuesOutOfFederationScope: u64 = 14;
 
 // ===== Constants =====
 const TIME_BUFFER_MS: u64 = 5000;
@@ -476,6 +479,14 @@ public fun create_accreditation_to_accredit(
         let federation_property = self.governance.properties.data().get(property.property_name());
         assert!(federation_property.is_valid_at_time(current_time_ms), EPropertyRevoked);
 
+        // The federation's declared property is a hard upper bound on the value
+        // space of any accreditation issued for it. This gate applies to every
+        // caller, including root authorities.
+        assert!(
+            federation_property.covers(property, current_time_ms),
+            EPropertyValuesOutOfFederationScope,
+        );
+
         idx = idx + 1;
     };
 
@@ -544,6 +555,14 @@ public fun create_accreditation_to_attest(
         // Check if property is revoked
         let federation_property = self.governance.properties.data().get(property.property_name());
         assert!(federation_property.is_valid_at_time(current_time_ms), EPropertyRevoked);
+
+        // The federation's declared property is a hard upper bound on the value
+        // space of any accreditation issued for it. This gate applies to every
+        // caller, including root authorities.
+        assert!(
+            federation_property.covers(property, current_time_ms),
+            EPropertyValuesOutOfFederationScope,
+        );
 
         idx = idx + 1;
     };
@@ -722,6 +741,12 @@ public fun validate_property(
         return false
     };
 
+    // Defense in depth: the value must lie inside the federation's declared
+    // value space, even if a (possibly buggy) accreditation carries it.
+    if (!federation_property.matches_value(&property_value, current_time_ms)) {
+        return false
+    };
+
     // Check if attester has accreditation permissions
     if (!self.is_attester(attester_id)) {
         return false
@@ -758,6 +783,13 @@ public fun validate_properties(
         // Check if the federation's property is still valid (not revoked)
         let federation_property = self.governance.properties.data().get(&property_name);
         if (!federation_property.is_valid_at_time(current_time_ms)) {
+            return false
+        };
+
+        // Defense in depth: the value must lie inside the federation's declared
+        // value space, even if a (possibly buggy) accreditation carries it.
+        let property_value = properties.get(&property_name);
+        if (!federation_property.matches_value(property_value, current_time_ms)) {
             return false
         };
 
@@ -800,6 +832,31 @@ fun is_revoked_root_authority(self: &Federation, id: &ID): bool {
 }
 
 // ===== Test Functions =====
+
+/// Injects an attest accreditation directly into governance, bypassing the
+/// `create_accreditation_to_attest` value-scope gate. Used only to construct
+/// out-of-scope accreditations for defense-in-depth validation tests.
+#[test_only]
+public(package) fun test_only_insert_attest_accreditation(
+    self: &mut Federation,
+    receiver: ID,
+    properties: vector<FederationProperty>,
+    ctx: &mut TxContext,
+) {
+    let accreditation = accreditation::new_accreditation(properties, ctx);
+    if (self.governance.accreditations_to_attest.contains(&receiver)) {
+        self
+            .governance
+            .accreditations_to_attest
+            .get_mut(&receiver)
+            .add_accreditation(accreditation);
+    } else {
+        let mut accreditations = accreditation::new_empty_accreditations();
+        accreditations.add_accreditation(accreditation);
+        self.governance.accreditations_to_attest.insert(receiver, accreditations);
+    };
+}
+
 #[test_only]
 public(package) fun transfer_root_authority_cap(
     self: &Federation,

--- a/hierarchies-move/sources/property.move
+++ b/hierarchies-move/sources/property.move
@@ -136,6 +136,61 @@ public(package) fun matches_value(
     self.allowed_values.contains(value)
 }
 
+/// Checks whether `requested`'s value space is a subset of `self`'s value space,
+/// i.e. whether `self` (the federation's declared property) covers every value
+/// that an accreditation carrying `requested` could ever match.
+///
+/// `self` is the federation's `FederationProperty` (the hard upper bound);
+/// `requested` is the condition a new accreditation would carry. Used to
+/// reject accreditations whose value space is broader than the federation's
+/// declaration, regardless of who the caller is.
+///
+/// Rules (conservative — only provably in-bounds requests are accepted):
+/// - If the federation allows any value, every request is trivially covered.
+/// - A bounded federation can never be widened back to `allow_any`.
+/// - A requested `shape` is only accepted when it is exactly equal to the
+///   federation's `shape`; arbitrary shape-subset reasoning is not attempted.
+/// - Every concrete value in `requested.allowed_values` must lie in the
+///   federation's value space (matching its `shape` or its `allowed_values`).
+public(package) fun covers(
+    self: &FederationProperty,
+    requested: &FederationProperty,
+    current_time_ms: u64,
+): bool {
+    // The federation admits everything, so any requested condition is in-bounds.
+    if (self.allow_any) {
+        return true
+    };
+
+    // A bounded federation cannot be widened back to "any value".
+    if (requested.allow_any) {
+        return false
+    };
+
+    // A requested shape is only in-bounds if it is identical to the
+    // federation's shape. We do not attempt to prove shape-subset relations.
+    if (requested.shape.is_some()) {
+        if (self.shape.is_none()) {
+            return false
+        };
+        if (!self.shape.borrow().equals(requested.shape.borrow())) {
+            return false
+        };
+    };
+
+    // Every concrete requested value must be inside the federation's value space.
+    let requested_values = requested.allowed_values.keys();
+    let mut idx = 0;
+    while (idx < requested_values.length()) {
+        if (!self.matches_value(&requested_values[idx], current_time_ms)) {
+            return false
+        };
+        idx = idx + 1;
+    };
+
+    true
+}
+
 public(package) fun revoke(self: &mut FederationProperty, valid_to_ms: u64) {
     self.timespan.valid_until_ms = option::some(valid_to_ms)
 }

--- a/hierarchies-move/sources/property_shape.move
+++ b/hierarchies-move/sources/property_shape.move
@@ -37,6 +37,32 @@ public fun new_property_shape_lower_than(value: u64): PropertyShape {
     PropertyShape::LowerThan(value)
 }
 
+/// Checks if two shapes are exactly equal (same variant and same parameter).
+public(package) fun equals(self: &PropertyShape, other: &PropertyShape): bool {
+    match (self) {
+        PropertyShape::StartsWith(a) => match (other) {
+            PropertyShape::StartsWith(b) => a == b,
+            _ => false,
+        },
+        PropertyShape::EndsWith(a) => match (other) {
+            PropertyShape::EndsWith(b) => a == b,
+            _ => false,
+        },
+        PropertyShape::Contains(a) => match (other) {
+            PropertyShape::Contains(b) => a == b,
+            _ => false,
+        },
+        PropertyShape::GreaterThan(a) => match (other) {
+            PropertyShape::GreaterThan(b) => a == b,
+            _ => false,
+        },
+        PropertyShape::LowerThan(a) => match (other) {
+            PropertyShape::LowerThan(b) => a == b,
+            _ => false,
+        },
+    }
+}
+
 /// Checks if the condition matches the value.
 public fun property_shape_matches(self: &PropertyShape, value: &PropertyValue): bool {
     match (self) {

--- a/hierarchies-move/tests/hierarchies_tests.move
+++ b/hierarchies-move/tests/hierarchies_tests.move
@@ -15,11 +15,13 @@ use hierarchies::{
         add_root_authority,
         revoke_root_authority,
         is_root_authority,
-        revoke_property
+        revoke_property,
+        test_only_insert_attest_accreditation
     },
     property,
     property_name::new_property_name,
-    property_value::new_property_value_number
+    property_shape::new_property_shape_starts_with,
+    property_value::{new_property_value_number, new_property_value_string}
 };
 use iota::{clock, test_scenario, vec_map, vec_set};
 use std::string::utf8;
@@ -1293,6 +1295,395 @@ fun test_validate_properties_fails_for_revoked_property() {
     test_scenario::return_shared(fed);
     test_scenario::return_to_address(alice, root_cap);
     test_scenario::return_to_address(alice, accredit_cap);
+    clock.destroy_for_testing();
+    let _ = scenario.end();
+}
+
+// ===== Federation value-scope enforcement =====
+
+#[test]
+#[expected_failure(abort_code = hierarchies::main::EPropertyValuesOutOfFederationScope)]
+fun test_create_accreditation_to_accredit_fails_for_value_out_of_scope() {
+    let alice = @0x1;
+    let mut scenario = test_scenario::begin(alice);
+    let mut clock = clock::create_for_testing(scenario.ctx());
+    clock.set_for_testing(1000);
+
+    new_federation(scenario.ctx());
+    scenario.next_tx(alice);
+
+    let mut fed: Federation = scenario.take_shared();
+    let cap: RootAuthorityCap = scenario.take_from_address(alice);
+    let accredit_cap: AccreditCap = scenario.take_from_address(alice);
+
+    // Federation declares test-property with allowed_values = {"a"}.
+    let property_name = new_property_name(utf8(b"test-property"));
+    let mut federation_values = vec_set::empty();
+    federation_values.insert(new_property_value_string(utf8(b"a")));
+    let federation_property = property::new_property(
+        property_name,
+        federation_values,
+        false,
+        option::none(),
+    );
+    fed.add_property(&cap, federation_property, scenario.ctx());
+    scenario.next_tx(alice);
+
+    let new_id = scenario.new_object();
+    let bob = new_id.uid_to_inner();
+
+    // Request an accreditation for "b" — outside the federation's value space.
+    let mut requested_values = vec_set::empty();
+    requested_values.insert(new_property_value_string(utf8(b"b")));
+    let requested = property::new_property(property_name, requested_values, false, option::none());
+
+    // Should abort with EPropertyValuesOutOfFederationScope, even though alice
+    // is a root authority.
+    fed.create_accreditation_to_accredit(
+        &accredit_cap,
+        bob,
+        vector[requested],
+        &clock,
+        scenario.ctx(),
+    );
+
+    // Cleanup - not reached due to expected failure.
+    test_scenario::return_to_address(alice, cap);
+    test_scenario::return_to_address(alice, accredit_cap);
+    test_scenario::return_shared(fed);
+    new_id.delete();
+    clock.destroy_for_testing();
+    let _ = scenario.end();
+}
+
+#[test]
+#[expected_failure(abort_code = hierarchies::main::EPropertyValuesOutOfFederationScope)]
+fun test_create_accreditation_to_attest_fails_for_value_out_of_scope() {
+    let alice = @0x1;
+    let mut scenario = test_scenario::begin(alice);
+    let mut clock = clock::create_for_testing(scenario.ctx());
+    clock.set_for_testing(1000);
+
+    new_federation(scenario.ctx());
+    scenario.next_tx(alice);
+
+    let mut fed: Federation = scenario.take_shared();
+    let cap: RootAuthorityCap = scenario.take_from_address(alice);
+    let accredit_cap: AccreditCap = scenario.take_from_address(alice);
+
+    // Federation declares test-property with allowed_values = {"a"}.
+    let property_name = new_property_name(utf8(b"test-property"));
+    let mut federation_values = vec_set::empty();
+    federation_values.insert(new_property_value_string(utf8(b"a")));
+    let federation_property = property::new_property(
+        property_name,
+        federation_values,
+        false,
+        option::none(),
+    );
+    fed.add_property(&cap, federation_property, scenario.ctx());
+    scenario.next_tx(alice);
+
+    let new_id = scenario.new_object();
+    let bob = new_id.uid_to_inner();
+
+    // Request an accreditation for "c" — outside the federation's value space.
+    let mut requested_values = vec_set::empty();
+    requested_values.insert(new_property_value_string(utf8(b"c")));
+    let requested = property::new_property(property_name, requested_values, false, option::none());
+
+    fed.create_accreditation_to_attest(
+        &accredit_cap,
+        bob,
+        vector[requested],
+        &clock,
+        scenario.ctx(),
+    );
+
+    test_scenario::return_to_address(alice, cap);
+    test_scenario::return_to_address(alice, accredit_cap);
+    test_scenario::return_shared(fed);
+    new_id.delete();
+    clock.destroy_for_testing();
+    let _ = scenario.end();
+}
+
+#[test]
+#[expected_failure(abort_code = hierarchies::main::EPropertyValuesOutOfFederationScope)]
+fun test_create_accreditation_to_attest_fails_for_allow_any_widening() {
+    let alice = @0x1;
+    let mut scenario = test_scenario::begin(alice);
+    let mut clock = clock::create_for_testing(scenario.ctx());
+    clock.set_for_testing(1000);
+
+    new_federation(scenario.ctx());
+    scenario.next_tx(alice);
+
+    let mut fed: Federation = scenario.take_shared();
+    let cap: RootAuthorityCap = scenario.take_from_address(alice);
+    let accredit_cap: AccreditCap = scenario.take_from_address(alice);
+
+    // Federation declares a bounded property (allow_any = false).
+    let property_name = new_property_name(utf8(b"test-property"));
+    let mut federation_values = vec_set::empty();
+    federation_values.insert(new_property_value_string(utf8(b"a")));
+    let federation_property = property::new_property(
+        property_name,
+        federation_values,
+        false,
+        option::none(),
+    );
+    fed.add_property(&cap, federation_property, scenario.ctx());
+    scenario.next_tx(alice);
+
+    let new_id = scenario.new_object();
+    let bob = new_id.uid_to_inner();
+
+    // Request allow_any = true against a bounded federation — must be rejected.
+    let requested = property::new_property(
+        property_name,
+        vec_set::empty(),
+        true,
+        option::none(),
+    );
+
+    fed.create_accreditation_to_attest(
+        &accredit_cap,
+        bob,
+        vector[requested],
+        &clock,
+        scenario.ctx(),
+    );
+
+    test_scenario::return_to_address(alice, cap);
+    test_scenario::return_to_address(alice, accredit_cap);
+    test_scenario::return_shared(fed);
+    new_id.delete();
+    clock.destroy_for_testing();
+    let _ = scenario.end();
+}
+
+#[test]
+#[expected_failure(abort_code = hierarchies::main::EPropertyValuesOutOfFederationScope)]
+fun test_create_accreditation_to_attest_fails_for_shape_widening() {
+    let alice = @0x1;
+    let mut scenario = test_scenario::begin(alice);
+    let mut clock = clock::create_for_testing(scenario.ctx());
+    clock.set_for_testing(1000);
+
+    new_federation(scenario.ctx());
+    scenario.next_tx(alice);
+
+    let mut fed: Federation = scenario.take_shared();
+    let cap: RootAuthorityCap = scenario.take_from_address(alice);
+    let accredit_cap: AccreditCap = scenario.take_from_address(alice);
+
+    // Federation declares a property bounded by allowed_values, with no shape.
+    let property_name = new_property_name(utf8(b"test-property"));
+    let mut federation_values = vec_set::empty();
+    federation_values.insert(new_property_value_string(utf8(b"abc")));
+    let federation_property = property::new_property(
+        property_name,
+        federation_values,
+        false,
+        option::none(),
+    );
+    fed.add_property(&cap, federation_property, scenario.ctx());
+    scenario.next_tx(alice);
+
+    let new_id = scenario.new_object();
+    let bob = new_id.uid_to_inner();
+
+    // Request a shape while the federation has neither shape nor allow_any.
+    let requested = property::new_property(
+        property_name,
+        vec_set::empty(),
+        false,
+        option::some(new_property_shape_starts_with(utf8(b"a"))),
+    );
+
+    fed.create_accreditation_to_attest(
+        &accredit_cap,
+        bob,
+        vector[requested],
+        &clock,
+        scenario.ctx(),
+    );
+
+    test_scenario::return_to_address(alice, cap);
+    test_scenario::return_to_address(alice, accredit_cap);
+    test_scenario::return_shared(fed);
+    new_id.delete();
+    clock.destroy_for_testing();
+    let _ = scenario.end();
+}
+
+#[test]
+fun test_create_accreditation_to_attest_succeeds_for_value_subset() {
+    let alice = @0x1;
+    let mut scenario = test_scenario::begin(alice);
+    let mut clock = clock::create_for_testing(scenario.ctx());
+    clock.set_for_testing(1000);
+
+    new_federation(scenario.ctx());
+    scenario.next_tx(alice);
+
+    let mut fed: Federation = scenario.take_shared();
+    let cap: RootAuthorityCap = scenario.take_from_address(alice);
+    let accredit_cap: AccreditCap = scenario.take_from_address(alice);
+
+    // Federation declares allowed_values = {"a", "b"}.
+    let property_name = new_property_name(utf8(b"test-property"));
+    let mut federation_values = vec_set::empty();
+    federation_values.insert(new_property_value_string(utf8(b"a")));
+    federation_values.insert(new_property_value_string(utf8(b"b")));
+    let federation_property = property::new_property(
+        property_name,
+        federation_values,
+        false,
+        option::none(),
+    );
+    fed.add_property(&cap, federation_property, scenario.ctx());
+    scenario.next_tx(alice);
+
+    let new_id = scenario.new_object();
+    let bob = new_id.uid_to_inner();
+
+    // Request a strict subset {"a"} — should succeed.
+    let mut requested_values = vec_set::empty();
+    requested_values.insert(new_property_value_string(utf8(b"a")));
+    let requested = property::new_property(property_name, requested_values, false, option::none());
+
+    fed.create_accreditation_to_attest(
+        &accredit_cap,
+        bob,
+        vector[requested],
+        &clock,
+        scenario.ctx(),
+    );
+    scenario.next_tx(alice);
+
+    assert!(fed.is_attester(&bob), 0);
+    // The granted (in-scope) value validates.
+    assert!(
+        fed.validate_property(&bob, property_name, new_property_value_string(utf8(b"a")), &clock),
+        1,
+    );
+
+    test_scenario::return_to_address(alice, cap);
+    test_scenario::return_to_address(alice, accredit_cap);
+    test_scenario::return_shared(fed);
+    new_id.delete();
+    clock.destroy_for_testing();
+    let _ = scenario.end();
+}
+
+#[test]
+fun test_create_accreditation_to_attest_succeeds_for_allow_any_federation() {
+    let alice = @0x1;
+    let mut scenario = test_scenario::begin(alice);
+    let mut clock = clock::create_for_testing(scenario.ctx());
+    clock.set_for_testing(1000);
+
+    new_federation(scenario.ctx());
+    scenario.next_tx(alice);
+
+    let mut fed: Federation = scenario.take_shared();
+    let cap: RootAuthorityCap = scenario.take_from_address(alice);
+    let accredit_cap: AccreditCap = scenario.take_from_address(alice);
+
+    // Federation declares allow_any = true.
+    let property_name = new_property_name(utf8(b"test-property"));
+    let federation_property = property::new_property(
+        property_name,
+        vec_set::empty(),
+        true,
+        option::none(),
+    );
+    fed.add_property(&cap, federation_property, scenario.ctx());
+    scenario.next_tx(alice);
+
+    let new_id = scenario.new_object();
+    let bob = new_id.uid_to_inner();
+
+    // Request allow_any = true — allowed because the federation also allows any.
+    let requested = property::new_property(
+        property_name,
+        vec_set::empty(),
+        true,
+        option::none(),
+    );
+
+    fed.create_accreditation_to_attest(
+        &accredit_cap,
+        bob,
+        vector[requested],
+        &clock,
+        scenario.ctx(),
+    );
+    scenario.next_tx(alice);
+
+    assert!(fed.is_attester(&bob), 0);
+
+    test_scenario::return_to_address(alice, cap);
+    test_scenario::return_to_address(alice, accredit_cap);
+    test_scenario::return_shared(fed);
+    new_id.delete();
+    clock.destroy_for_testing();
+    let _ = scenario.end();
+}
+
+#[test]
+fun test_validate_property_refuses_out_of_scope_accreditation() {
+    let alice = @0x1;
+    let mut scenario = test_scenario::begin(alice);
+    let mut clock = clock::create_for_testing(scenario.ctx());
+    clock.set_for_testing(1000);
+
+    new_federation(scenario.ctx());
+    scenario.next_tx(alice);
+
+    let mut fed: Federation = scenario.take_shared();
+    let cap: RootAuthorityCap = scenario.take_from_address(alice);
+
+    // Federation declares allowed_values = {"a"}.
+    let property_name = new_property_name(utf8(b"test-property"));
+    let mut federation_values = vec_set::empty();
+    federation_values.insert(new_property_value_string(utf8(b"a")));
+    let federation_property = property::new_property(
+        property_name,
+        federation_values,
+        false,
+        option::none(),
+    );
+    fed.add_property(&cap, federation_property, scenario.ctx());
+    scenario.next_tx(alice);
+
+    let bob_id = @0x2.to_id();
+
+    // Inject an out-of-scope attest accreditation for "c", bypassing the
+    // creation gate (simulating an accreditation issued by a prior buggy
+    // package version).
+    let mut bad_values = vec_set::empty();
+    bad_values.insert(new_property_value_string(utf8(b"c")));
+    let bad_property = property::new_property(property_name, bad_values, false, option::none());
+    fed.test_only_insert_attest_accreditation(bob_id, vector[bad_property], scenario.ctx());
+    scenario.next_tx(alice);
+
+    // Even though Bob's accreditation carries "c", validation must refuse it
+    // because the federation never allowed "c".
+    assert!(
+        !fed.validate_property(
+            &bob_id,
+            property_name,
+            new_property_value_string(utf8(b"c")),
+            &clock,
+        ),
+        0,
+    );
+
+    test_scenario::return_to_address(alice, cap);
+    test_scenario::return_shared(fed);
     clock.destroy_for_testing();
     let _ = scenario.end();
 }

--- a/hierarchies-rs/examples/real-world/01_university_degrees.rs
+++ b/hierarchies-rs/examples/real-world/01_university_degrees.rs
@@ -172,20 +172,21 @@ async fn main() -> anyhow::Result<()> {
 
     println!("✅ Field Mathematics property added!");
     // Add GPA property with advanced numeric validation (must be between 2.0-4.0)
+    let gpa_values = HashSet::from([
+        PropertyValue::Number(200),
+        PropertyValue::Number(250),
+        PropertyValue::Number(300),
+        PropertyValue::Number(320),
+        PropertyValue::Number(350),
+        PropertyValue::Number(380),
+        PropertyValue::Number(400), // Common GPA ranges: 2.0, 2.5, 3.0, 3.2, 3.5, 3.8, 4.0
+    ]);
     hierarchies_client
         .add_property(
             *university_consortium.id.object_id(),
             FederationProperty::new(grade_gpa.clone())
                 .with_expression(PropertyShape::GreaterThan(200)) // GPA > 2.0 (stored as 200 for precision)
-                .with_allowed_values(HashSet::from([
-                    PropertyValue::Number(200),
-                    PropertyValue::Number(250),
-                    PropertyValue::Number(300),
-                    PropertyValue::Number(320),
-                    PropertyValue::Number(350),
-                    PropertyValue::Number(380),
-                    PropertyValue::Number(400), // Common GPA ranges: 2.0, 2.5, 3.0, 3.2, 3.5, 3.8, 4.0
-                ])),
+                .with_allowed_values(gpa_values.clone()),
         )
         .build_and_execute(&hierarchies_client)
         .await?;
@@ -193,25 +194,26 @@ async fn main() -> anyhow::Result<()> {
     println!("✅ GPA property added!");
 
     // Add graduation year with range validation (must be recent - from 1950 onwards)
+    let graduation_year_values = HashSet::from([
+        PropertyValue::Number(1950),
+        PropertyValue::Number(1960),
+        PropertyValue::Number(1970),
+        PropertyValue::Number(1980),
+        PropertyValue::Number(1990),
+        PropertyValue::Number(2000),
+        PropertyValue::Number(2010),
+        PropertyValue::Number(2020),
+        PropertyValue::Number(2021),
+        PropertyValue::Number(2022),
+        PropertyValue::Number(2023),
+        PropertyValue::Number(2024),
+    ]);
     hierarchies_client
         .add_property(
             *university_consortium.id.object_id(),
             FederationProperty::new(graduation_year.clone())
                 .with_expression(PropertyShape::GreaterThan(1950))
-                .with_allowed_values(HashSet::from([
-                    PropertyValue::Number(1950),
-                    PropertyValue::Number(1960),
-                    PropertyValue::Number(1970),
-                    PropertyValue::Number(1980),
-                    PropertyValue::Number(1990),
-                    PropertyValue::Number(2000),
-                    PropertyValue::Number(2010),
-                    PropertyValue::Number(2020),
-                    PropertyValue::Number(2021),
-                    PropertyValue::Number(2022),
-                    PropertyValue::Number(2023),
-                    PropertyValue::Number(2024),
-                ])),
+                .with_allowed_values(graduation_year_values.clone()),
         )
         .build_and_execute(&hierarchies_client)
         .await?;
@@ -299,16 +301,19 @@ async fn main() -> anyhow::Result<()> {
     // Simulate Harvard CS Faculty address
     let harvard_cs_faculty = IotaAddress::random();
 
-    // Harvard delegates accreditation rights to its CS Faculty
-    // This allows the faculty to further delegate to registrars and professors
+    // Harvard delegates accreditation rights to its CS Faculty.
+    // This allows the faculty to further delegate to registrars and professors.
+    // The delegated value space must stay within the federation's declared
+    // bounds for each property, so we delegate the federation's full set of
+    // allowed values rather than `allow_any`.
     let cs_faculty_properties = vec![
-        FederationProperty::new(degree_bachelor.clone()).with_allow_any(true),
-        FederationProperty::new(degree_master.clone()).with_allow_any(true),
-        FederationProperty::new(degree_phd.clone()).with_allow_any(true),
-        FederationProperty::new(field_cs.clone()).with_allow_any(true),
-        FederationProperty::new(grade_gpa.clone()).with_allow_any(true),
-        FederationProperty::new(graduation_year.clone()).with_allow_any(true),
-        FederationProperty::new(student_verified.clone()).with_allow_any(true),
+        FederationProperty::new(degree_bachelor.clone()).with_allowed_values(degree_values.clone()),
+        FederationProperty::new(degree_master.clone()).with_allowed_values(degree_values.clone()),
+        FederationProperty::new(degree_phd.clone()).with_allowed_values(degree_values.clone()),
+        FederationProperty::new(field_cs.clone()).with_allowed_values(boolean_values.clone()),
+        FederationProperty::new(grade_gpa.clone()).with_allowed_values(gpa_values.clone()),
+        FederationProperty::new(graduation_year.clone()).with_allowed_values(graduation_year_values.clone()),
+        FederationProperty::new(student_verified.clone()).with_allowed_values(boolean_values.clone()),
     ];
 
     hierarchies_client

--- a/hierarchies-rs/examples/real-world/02_supply_chain.rs
+++ b/hierarchies-rs/examples/real-world/02_supply_chain.rs
@@ -396,15 +396,19 @@ async fn main() -> anyhow::Result<()> {
     // German Testing Institute under ISO Europe
     let german_testing_institute = IotaAddress::random();
 
-    // Create comprehensive accreditation package for German institute
+    // Create comprehensive accreditation package for German institute.
+    // The delegated value space must stay within the federation's declared
+    // bounds, so we delegate each property's declared allowed values. Only
+    // `origin_verified` and `expiry_date` are declared `allow_any` by the
+    // federation, so they may be delegated as `allow_any`.
     let european_cert_properties = vec![
-        FederationProperty::new(iso_9001.clone()).with_allow_any(true),
-        FederationProperty::new(iso_14001.clone()).with_allow_any(true),
-        FederationProperty::new(iso_22000.clone()).with_allow_any(true),
-        FederationProperty::new(product_organic.clone()).with_allow_any(true),
+        FederationProperty::new(iso_9001.clone()).with_allowed_values(cert_status_values.clone()),
+        FederationProperty::new(iso_14001.clone()).with_allowed_values(cert_status_values.clone()),
+        FederationProperty::new(iso_22000.clone()).with_allowed_values(cert_status_values.clone()),
+        FederationProperty::new(product_organic.clone()).with_allowed_values(boolean_values.clone()),
         FederationProperty::new(origin_verified.clone()).with_allow_any(true),
-        FederationProperty::new(batch_tested.clone()).with_allow_any(true),
-        FederationProperty::new(compliance_eu.clone()).with_allow_any(true),
+        FederationProperty::new(batch_tested.clone()).with_allowed_values(test_results.clone()),
+        FederationProperty::new(compliance_eu.clone()).with_allowed_values(boolean_values.clone()),
         FederationProperty::new(expiry_date.clone()).with_allow_any(true),
     ];
 
@@ -422,12 +426,12 @@ async fn main() -> anyhow::Result<()> {
     let us_fda_regional = IotaAddress::random();
 
     let americas_cert_properties = vec![
-        FederationProperty::new(iso_9001.clone()).with_allow_any(true),
-        FederationProperty::new(iso_22000.clone()).with_allow_any(true),
-        FederationProperty::new(product_organic.clone()).with_allow_any(true),
+        FederationProperty::new(iso_9001.clone()).with_allowed_values(cert_status_values.clone()),
+        FederationProperty::new(iso_22000.clone()).with_allowed_values(cert_status_values.clone()),
+        FederationProperty::new(product_organic.clone()).with_allowed_values(boolean_values.clone()),
         FederationProperty::new(origin_verified.clone()).with_allow_any(true),
-        FederationProperty::new(batch_tested.clone()).with_allow_any(true),
-        FederationProperty::new(compliance_fda.clone()).with_allow_any(true),
+        FederationProperty::new(batch_tested.clone()).with_allowed_values(test_results.clone()),
+        FederationProperty::new(compliance_fda.clone()).with_allowed_values(boolean_values.clone()),
         FederationProperty::new(expiry_date.clone()).with_allow_any(true),
     ];
 
@@ -456,11 +460,11 @@ async fn main() -> anyhow::Result<()> {
 
     // Focus on food safety and organic certifications
     let food_safety_properties = vec![
-        FederationProperty::new(iso_22000.clone()).with_allow_any(true),
-        FederationProperty::new(product_organic.clone()).with_allow_any(true),
+        FederationProperty::new(iso_22000.clone()).with_allowed_values(cert_status_values.clone()),
+        FederationProperty::new(product_organic.clone()).with_allowed_values(boolean_values.clone()),
         FederationProperty::new(origin_verified.clone()).with_allow_any(true),
-        FederationProperty::new(batch_tested.clone()).with_allow_any(true),
-        FederationProperty::new(compliance_eu.clone()).with_allow_any(true),
+        FederationProperty::new(batch_tested.clone()).with_allowed_values(test_results.clone()),
+        FederationProperty::new(compliance_eu.clone()).with_allowed_values(boolean_values.clone()),
         FederationProperty::new(expiry_date.clone()).with_allow_any(true),
     ];
 

--- a/hierarchies-rs/hierarchies/tests/e2e/test_accreditations.rs
+++ b/hierarchies-rs/hierarchies/tests/e2e/test_accreditations.rs
@@ -63,6 +63,64 @@ async fn test_create_accreditation_to_attest() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn test_create_accreditation_out_of_federation_scope_fails() -> anyhow::Result<()> {
+    let client = get_funded_test_client().await?;
+
+    // Create a new federation.
+    let federation_id = client
+        .create_new_federation()
+        .build_and_execute(&client)
+        .await?
+        .output
+        .id;
+
+    // Federation declares test-property with allowed_values = {"a"}.
+    let property_name = PropertyName::from("test-property");
+    let mut allowed_values = HashSet::new();
+    allowed_values.insert(PropertyValue::Text("a".to_string()));
+
+    client
+        .add_property(
+            *federation_id.object_id(),
+            FederationProperty::new(property_name.clone()).with_allowed_values(allowed_values),
+        )
+        .build_and_execute(&client)
+        .await?;
+
+    // Attempt to issue an accreditation for "b", which is outside the
+    // federation's declared value space. This must be rejected on-chain
+    // (EPropertyValuesOutOfFederationScope), even though the caller is a root
+    // authority.
+    let mut out_of_scope = HashSet::new();
+    out_of_scope.insert(PropertyValue::Text("b".to_string()));
+    let property = FederationProperty::new(property_name).with_allowed_values(out_of_scope);
+
+    let receiver_id = ObjectID::random();
+    let result = client
+        .create_accreditation_to_accredit(*federation_id.object_id(), receiver_id, vec![property])
+        .build_and_execute(&client)
+        .await;
+
+    assert!(
+        result.is_err(),
+        "expected out-of-scope accreditation to be rejected, but it succeeded"
+    );
+
+    // The receiver must not have gained an accredit accreditation. (The map is
+    // never empty — the federation creator always holds an entry — so check the
+    // receiver specifically.)
+    let federation: Federation = client.get_federation_by_id(*federation_id.object_id()).await?;
+    assert!(
+        !federation
+            .governance
+            .accreditations_to_accredit
+            .contains_key(&receiver_id)
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_create_accreditation_to_accredit() -> anyhow::Result<()> {
     let client = get_funded_test_client().await?;
 


### PR DESCRIPTION
# Description

fixes #183 

## Changes

- Add a `covers` check on the Move side that treats the federation's declared property as a hard upper bound: federation `allow_any` covers anything; a bounded federation can't be widened back to `allow_any`; a requested `shape` is accepted only when exactly equal to the federation's; every requested value must lie in the federation's value space.
- Apply this check in both `create_accreditation_to_accredit` and  `create_accreditation_to_attest`, **for every caller including root authorities**, aborting with a new `EPropertyValuesOutOfFederationScope` code when a request is out of scope.
- Re-check the value against the federation's declaration in `validate_property` / `validate_properties` as defense in depth, so even an accreditation issued by a prior buggy package version cannot be honored.

## Additional necessary changes

- The two real-world examples delegated rights with `allow_any=true` for properties the federation bounds — i.e. they relied on the bug - so they abort under the new gate. Updated them (Rust and Wasm in lockstep) to delegate each property's declared value set instead, keeping `allow_any` only where the federation itself declares it.
- Restored two missing value-shape constraints in the Wasm university example so it again mirrors its Rust counterpart.
- Added regression tests on every layer (Move, Rust e2e, Wasm) covering the out-of-scope rejection and the in-scope happy paths.

## Breaking change

No - at the  API level. 
Yes - behaviorally. 

## Testing

e2e works + additional example that tests discovered issue

