### PR TITLE
bump the iota to 1.24 and product core to 0.8.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1902,7 +1902,7 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 [[package]]
 name = "enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "serde_yaml",
 ]
@@ -2681,7 +2681,7 @@ dependencies = [
  "chrono",
  "hierarchies",
  "hyper",
- "iota-sdk 1.23.2",
+ "iota-sdk 1.24.0",
  "product_common",
  "tokio",
 ]
@@ -3116,7 +3116,7 @@ dependencies = [
 [[package]]
 name = "iota-adapter-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3144,20 +3144,15 @@ dependencies = [
 
 [[package]]
 name = "iota-common"
-version = "1.23.2"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+version = "1.24.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
- "anyhow",
- "fastcrypto",
  "futures",
  "iota-macros",
  "iota-metrics",
- "iota-types",
  "once_cell",
  "parking_lot 0.12.5",
  "rand 0.8.6",
- "reqwest 0.12.28",
- "snap",
  "tempfile",
  "tokio",
  "tracing",
@@ -3165,8 +3160,8 @@ dependencies = [
 
 [[package]]
 name = "iota-config"
-version = "1.23.2"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+version = "1.24.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "anemo",
  "anyhow",
@@ -3228,8 +3223,8 @@ dependencies = [
 
 [[package]]
 name = "iota-enum-compat-util"
-version = "1.23.2"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+version = "1.24.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "serde_yaml",
 ]
@@ -3237,7 +3232,7 @@ dependencies = [
 [[package]]
 name = "iota-execution"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "iota-adapter-latest",
  "iota-move-natives-latest",
@@ -3254,8 +3249,8 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-common"
-version = "1.23.2"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+version = "1.24.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "iota-execution",
  "iota-protocol-config",
@@ -3265,8 +3260,8 @@ dependencies = [
 
 [[package]]
 name = "iota-http"
-version = "1.23.2"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+version = "1.24.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "bytes",
  "http",
@@ -3286,8 +3281,8 @@ dependencies = [
 
 [[package]]
 name = "iota-json"
-version = "1.23.2"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+version = "1.24.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3303,8 +3298,8 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-api"
-version = "1.23.2"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+version = "1.24.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -3323,8 +3318,8 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-types"
-version = "1.23.2"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+version = "1.24.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3339,7 +3334,6 @@ dependencies = [
  "iota-names",
  "iota-package-resolver",
  "iota-protocol-config",
- "iota-sdk-types",
  "iota-types",
  "itertools 0.13.0",
  "json_to_table",
@@ -3360,8 +3354,8 @@ dependencies = [
 
 [[package]]
 name = "iota-keys"
-version = "1.23.2"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+version = "1.24.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "anyhow",
  "bip32",
@@ -3381,8 +3375,8 @@ dependencies = [
 
 [[package]]
 name = "iota-macros"
-version = "1.23.2"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+version = "1.24.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "futures",
  "iota-proc-macros",
@@ -3392,8 +3386,8 @@ dependencies = [
 
 [[package]]
 name = "iota-metrics"
-version = "1.23.2"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+version = "1.24.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -3419,7 +3413,7 @@ dependencies = [
 [[package]]
 name = "iota-move-natives-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "bcs",
  "better_any",
@@ -3442,21 +3436,20 @@ dependencies = [
 
 [[package]]
 name = "iota-names"
-version = "1.23.2"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+version = "1.24.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "anyhow",
  "bcs",
  "iota-types",
- "move-core-types",
  "serde",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "iota-network-stack"
-version = "1.23.2"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+version = "1.24.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "anemo",
  "bcs",
@@ -3485,8 +3478,8 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc"
-version = "1.23.2"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+version = "1.24.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -3496,8 +3489,8 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc-macros"
-version = "1.23.2"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+version = "1.24.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -3509,8 +3502,8 @@ dependencies = [
 
 [[package]]
 name = "iota-package-resolver"
-version = "1.23.2"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+version = "1.24.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "async-trait",
  "bcs",
@@ -3524,8 +3517,8 @@ dependencies = [
 
 [[package]]
 name = "iota-proc-macros"
-version = "1.23.2"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+version = "1.24.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "msim-macros",
  "proc-macro2",
@@ -3535,8 +3528,8 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config"
-version = "1.23.2"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+version = "1.24.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "clap",
  "iota-protocol-config-macros",
@@ -3550,8 +3543,8 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config-macros"
-version = "1.23.2"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+version = "1.24.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3591,8 +3584,8 @@ dependencies = [
 
 [[package]]
 name = "iota-sdk"
-version = "1.23.2"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+version = "1.24.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3613,7 +3606,6 @@ dependencies = [
  "iota-transaction-builder",
  "iota-types",
  "jsonrpsee",
- "move-core-types",
  "reqwest 0.12.28",
  "rustls",
  "serde",
@@ -3627,7 +3619,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=c37fbcc9ad56c92f23582dcdb8203e3594088639#c37fbcc9ad56c92f23582dcdb8203e3594088639"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=cdf7afb2ce3d785f1622711ef1800b18eea391f4#cdf7afb2ce3d785f1622711ef1800b18eea391f4"
 dependencies = [
  "base64ct",
  "bcs",
@@ -3652,8 +3644,8 @@ dependencies = [
 
 [[package]]
 name = "iota-tls"
-version = "1.23.2"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+version = "1.24.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3674,8 +3666,8 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-builder"
-version = "1.23.2"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+version = "1.24.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3686,13 +3678,12 @@ dependencies = [
  "iota-protocol-config",
  "iota-types",
  "move-binary-format",
- "move-core-types",
 ]
 
 [[package]]
 name = "iota-types"
-version = "1.23.2"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+version = "1.24.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "anemo",
  "anyhow",
@@ -3725,8 +3716,6 @@ dependencies = [
  "move-vm-profiler",
  "move-vm-test-utils",
  "nonempty",
- "num-bigint 0.4.6",
- "num-traits",
  "once_cell",
  "parking_lot 0.12.5",
  "passkey-types",
@@ -3753,7 +3742,7 @@ dependencies = [
 [[package]]
 name = "iota-verifier-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "bcs",
  "iota-types",
@@ -3768,8 +3757,8 @@ dependencies = [
 
 [[package]]
 name = "iota_interaction"
-version = "0.8.18"
-source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.18#9518c0a4544d2d25bdc0b6cc3af250fa39ec9ddf"
+version = "0.8.20"
+source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.20#950ec6a3801016c1750b529eb667579110f68014"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3783,7 +3772,7 @@ dependencies = [
  "hex",
  "hyper",
  "indexmap 2.14.0",
- "iota-sdk 1.23.2",
+ "iota-sdk 1.24.0",
  "iota-sdk-types",
  "itertools 0.13.0",
  "jsonpath-rust",
@@ -3812,8 +3801,8 @@ dependencies = [
 
 [[package]]
 name = "iota_interaction_rust"
-version = "0.8.18"
-source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.18#9518c0a4544d2d25bdc0b6cc3af250fa39ec9ddf"
+version = "0.8.20"
+source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.20#950ec6a3801016c1750b529eb667579110f68014"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3826,8 +3815,8 @@ dependencies = [
 
 [[package]]
 name = "iota_interaction_ts"
-version = "0.8.18"
-source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.18#9518c0a4544d2d25bdc0b6cc3af250fa39ec9ddf"
+version = "0.8.20"
+source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.20#950ec6a3801016c1750b529eb667579110f68014"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4496,7 +4485,7 @@ dependencies = [
 [[package]]
 name = "move-abstract-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "move-binary-format",
  "move-bytecode-verifier-meter",
@@ -4505,18 +4494,16 @@ dependencies = [
 [[package]]
 name = "move-abstract-stack"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "anyhow",
- "enum-compat-util",
  "indexmap 2.14.0",
  "move-core-types",
- "move-proc-macros",
  "ref-cast",
  "serde",
  "variant_count",
@@ -4525,12 +4512,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4546,21 +4533,20 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
  "move-binary-format",
  "move-core-types",
  "petgraph",
- "serde",
  "serde-reflection",
 ]
 
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -4576,7 +4562,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-meter"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -4586,7 +4572,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4606,7 +4592,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4614,7 +4600,6 @@ dependencies = [
  "codespan-reporting",
  "dunce",
  "hex",
- "insta",
  "lsp-types",
  "move-binary-format",
  "move-borrow-graph",
@@ -4634,14 +4619,13 @@ dependencies = [
  "serde_json",
  "similar",
  "stacker",
- "tempfile",
  "vfs",
 ]
 
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4665,7 +4649,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4686,10 +4670,9 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "anyhow",
- "bcs",
  "clap",
  "hex",
  "inline_colorization",
@@ -4707,7 +4690,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -4725,7 +4708,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "anyhow",
  "hex",
@@ -4738,7 +4721,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -4751,7 +4734,7 @@ dependencies = [
 [[package]]
 name = "move-proc-macros"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -4760,7 +4743,7 @@ dependencies = [
 [[package]]
 name = "move-regex-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -4770,7 +4753,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives"
 version = "0.1.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -4785,7 +4768,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "once_cell",
  "phf",
@@ -4795,7 +4778,7 @@ dependencies = [
 [[package]]
 name = "move-trace-format"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -4806,7 +4789,7 @@ dependencies = [
 [[package]]
 name = "move-vm-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "move-binary-format",
  "once_cell",
@@ -4815,17 +4798,16 @@ dependencies = [
 [[package]]
 name = "move-vm-profiler"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "move-vm-config",
- "once_cell",
  "serde",
 ]
 
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "better_any",
  "fail",
@@ -4845,7 +4827,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -4859,7 +4841,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -5876,8 +5858,8 @@ dependencies = [
 
 [[package]]
 name = "product_common"
-version = "0.8.18"
-source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.18#9518c0a4544d2d25bdc0b6cc3af250fa39ec9ddf"
+version = "0.8.20"
+source = "git+https://github.com/iotaledger/product-core.git?tag=v0.8.20#950ec6a3801016c1750b529eb667579110f68014"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5886,7 +5868,7 @@ dependencies = [
  "fastcrypto",
  "hyper",
  "iota-keys",
- "iota-sdk 1.23.2",
+ "iota-sdk 1.24.0",
  "iota-sdk-types",
  "iota_interaction",
  "iota_interaction_rust",
@@ -5922,8 +5904,8 @@ dependencies = [
 
 [[package]]
 name = "prometheus-closure-metric"
-version = "1.23.2"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+version = "1.24.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -7298,7 +7280,7 @@ dependencies = [
 [[package]]
 name = "starfish-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "blake3",
  "fastcrypto",
@@ -8076,8 +8058,8 @@ checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typed-store-error"
-version = "1.23.2"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.23.2#0ede760cba01c0a584b8aef42f3049cb4e708a8e"
+version = "1.24.0"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.24.0#2afd70dd05d16d252c80329d8a3b38d9e65dece5"
 dependencies = [
  "serde",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,11 @@ async-trait = "0.1"
 bcs = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 hyper = "1.8"
-iota-sdk = { package = "iota-sdk", git = "https://github.com/iotaledger/iota.git", tag = "v1.23.2" }
-iota_interaction = { package = "iota_interaction", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.18", default-features = false }
-iota_interaction_rust = { package = "iota_interaction_rust", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.18", default-features = false }
-iota_interaction_ts = { package = "iota_interaction_ts", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.18", default-features = false }
-product_common = { package = "product_common", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.18", default-features = false }
+iota-sdk = { package = "iota-sdk", git = "https://github.com/iotaledger/iota.git", tag = "v1.24.0" }
+iota_interaction = { package = "iota_interaction", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.20", default-features = false }
+iota_interaction_rust = { package = "iota_interaction_rust", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.20", default-features = false }
+iota_interaction_ts = { package = "iota_interaction_ts", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.20", default-features = false }
+product_common = { package = "product_common", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.20", default-features = false }
 secret-storage = { git = "https://github.com/iotaledger/secret-storage", tag = "v0.3.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.149"

--- a/bindings/wasm/hierarchies_wasm/Cargo.toml
+++ b/bindings/wasm/hierarchies_wasm/Cargo.toml
@@ -19,8 +19,8 @@ crate-type = ["cdylib", "rlib"]
 anyhow = "1.0"
 console_error_panic_hook = "0.1"
 hyper = "1.8"
-iota_interaction = { package = "iota_interaction", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.18", default-features = false }
-iota_interaction_ts = { package = "iota_interaction_ts", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.18" }
+iota_interaction = { package = "iota_interaction", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.20", default-features = false }
+iota_interaction_ts = { package = "iota_interaction_ts", git = "https://github.com/iotaledger/product-core.git", tag = "v0.8.20" }
 js-sys = { version = "=0.3.85" }
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6"
@@ -35,7 +35,7 @@ features = ["default-http-client", "gas-station"]
 [dependencies.product_common]
 package = "product_common"
 git = "https://github.com/iotaledger/product-core.git"
-tag = "v0.8.18"
+tag = "v0.8.20"
 features = [
   "default-http-client",
   "binding-utils",

--- a/bindings/wasm/hierarchies_wasm/package-lock.json
+++ b/bindings/wasm/hierarchies_wasm/package-lock.json
@@ -37,7 +37,7 @@
                 "node": ">=20"
             },
             "peerDependencies": {
-                "@iota/iota-sdk": "^1.13.0"
+                "@iota/iota-sdk": "^1.14.0"
             }
         },
         "node_modules/@0no-co/graphql.web": {

--- a/bindings/wasm/hierarchies_wasm/package.json
+++ b/bindings/wasm/hierarchies_wasm/package.json
@@ -77,7 +77,7 @@
         "@iota/iota-interaction-ts": "^0.14.0"
     },
     "peerDependencies": {
-        "@iota/iota-sdk": "^1.13.0"
+        "@iota/iota-sdk": "^1.14.0"
     },
     "engines": {
         "node": ">=20"

--- a/bindings/wasm/hierarchies_wasm/src/client_read_only.rs
+++ b/bindings/wasm/hierarchies_wasm/src/client_read_only.rs
@@ -492,6 +492,14 @@ impl WasmHierarchiesClientReadOnly {
             .map_err(wasm_error)?;
         Ok(is_valid)
     }
+
+    /// Returns the `tf_components` package ID currently in use.
+    ///
+    /// @returns Stringified object ID of the resolved `tf_components` package.
+    #[wasm_bindgen(js_name = tfComponentsPackageId)]
+    pub fn tf_components_package_id(&self) -> String {
+        self.0.tf_components_package_id().unwrap_or(ObjectID::ZERO).to_string()
+    }
 }
 
 fn call_js_method(obj: &JsValue, method: &str) -> Option<JsValue> {

--- a/bindings/wasm/hierarchies_wasm/src/full_client.rs
+++ b/bindings/wasm/hierarchies_wasm/src/full_client.rs
@@ -5,6 +5,7 @@ use hierarchies::client::HierarchiesClient;
 use iota_interaction_ts::WasmPublicKey;
 use iota_interaction_ts::bindings::{WasmIotaClient, WasmTransactionSigner};
 use iota_interaction_ts::wasm_error::{Result, WasmResult};
+use iota_interaction::types::base_types::ObjectID;
 use product_common::bindings::transaction::WasmTransactionBuilder;
 use product_common::bindings::utils::{into_transaction_builder, parse_wasm_object_id};
 use product_common::bindings::{WasmIotaAddress, WasmObjectID};
@@ -317,5 +318,13 @@ impl WasmHierarchiesClient {
     #[wasm_bindgen(js_name = readOnly)]
     pub fn read_only(&self) -> WasmHierarchiesClientReadOnly {
         WasmHierarchiesClientReadOnly((*self.0).clone())
+    }
+
+    /// Returns the `tf_components` package ID currently in use.
+    ///
+    /// @returns Stringified object ID of the resolved `tf_components` package.
+    #[wasm_bindgen(js_name = tfComponentsPackageId)]
+    pub fn tf_components_package_id(&self) -> String {
+        self.0.tf_components_package_id().unwrap_or(ObjectID::ZERO).to_string()
     }
 }

--- a/bindings/wasm/hierarchies_wasm/src/full_client.rs
+++ b/bindings/wasm/hierarchies_wasm/src/full_client.rs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use hierarchies::client::HierarchiesClient;
+use iota_interaction::types::base_types::ObjectID;
 use iota_interaction_ts::WasmPublicKey;
 use iota_interaction_ts::bindings::{WasmIotaClient, WasmTransactionSigner};
 use iota_interaction_ts::wasm_error::{Result, WasmResult};
-use iota_interaction::types::base_types::ObjectID;
 use product_common::bindings::transaction::WasmTransactionBuilder;
 use product_common::bindings::utils::{into_transaction_builder, parse_wasm_object_id};
 use product_common::bindings::{WasmIotaAddress, WasmObjectID};


### PR DESCRIPTION
# Description of change

Following dependencies have been changed:
- [ ] tokio version update to: -
- [ ] fastcrypto version update to rev = "-"
- [ ] notarization_wasm: new peerDep. version for @iota/iota-sdk: _
- [ ] notarization_wasm: new dependency version for @iota/iota-interaction-ts: _
- [x] hierarchies_wasm: new peerDep. version for @iota/iota-sdk: `"^1.14.0"`
- [x] pin all product-core.git dependencies to `tag = "v0.8.20"`
- [x] pin all iota.git dependencies to `tag = "v1.24.0"`


## Links to any relevant issues
https://github.com/iotaledger/product-core/issues/67