### PR TITLE
Replace wasm-opt in bindings dep with local version

### DIFF
--- a/.github/workflows/shared-build-wasm.yml
+++ b/.github/workflows/shared-build-wasm.yml
@@ -60,6 +60,13 @@ jobs:
         with:
           version: "0.2.108"
 
+      # Install wasm-opt from binaryen repository.
+      - name: Install binaryen
+        uses: sigoden/install-binary@v1
+        with:
+          repo: WebAssembly/binaryen
+          name: wasm-opt
+
       - name: Setup sccache
         uses: "./.github/actions/rust/sccache/setup"
         with:

--- a/bindings/wasm/hierarchies_wasm/README.md
+++ b/bindings/wasm/hierarchies_wasm/README.md
@@ -35,10 +35,13 @@ to [rustup.rs](https://rustup.rs) for the installation.
 - for running example: a local network node with the IOTA hierarchies package deployed as being described
   [here](https://docs.iota.org/developer/iota-hierarchies/getting-started/local-network-setup)
 
-### 1. Install `wasm-bindgen-cli`
+### 1. Install Local Tooling
 
-If you want to build the library from source,
-you will first need to manually install [`wasm-bindgen-cli`](https://github.com/rustwasm/wasm-bindgen).
+If you want to build the library from source you have to install additional build tools locally.
+
+#### Install `wasm-bindgen-cli`
+
+First you need to install [`wasm-bindgen-cli`](https://github.com/rustwasm/wasm-bindgen).
 A manual installation is required because we use the [Weak References](https://rustwasm.github.io/wasm-bindgen/reference/weak-references.html) feature,
 which [`wasm-pack` does not expose](https://github.com/rustwasm/wasm-pack/issues/930).
 
@@ -46,9 +49,20 @@ which [`wasm-pack` does not expose](https://github.com/rustwasm/wasm-pack/issues
 cargo install --force wasm-bindgen-cli
 ```
 
+#### Install `wasm-opt`
+
+To reduce the size of the wasm package, it is optimized with `wasm-opt`, which is part of [`binaryen`](https://github.com/WebAssembly/binaryen).
+
+You can either download a [release of binaryen](https://github.com/WebAssembly/binaryen/releases) and make the bin folder available in your PATH or check if your operating system tooling offers a more convenient way of installing the binaries like APT, Homebrew, etc.
+
+Some examples:
+
+- Linux via APT: `sudo apt-get update && sudo apt-get -y install binaryen` (taken from [here](https://installati.one/install-binaryen-ubuntu-22-04/))
+- MacOS via Homebrew: `brew install binaryen` (see [Homebrew entry](https://formulae.brew.sh/formula/binaryen))
+
 ### 2. Install Dependencies
 
-After installing `wasm-bindgen-cli`, you can install the necessary dependencies using the following command:
+After installing local tooling, you can install the necessary dependencies using the following command:
 
 ```bash
 npm install

--- a/bindings/wasm/hierarchies_wasm/package-lock.json
+++ b/bindings/wasm/hierarchies_wasm/package-lock.json
@@ -30,8 +30,7 @@
                 "txm": "^8.1.0",
                 "typedoc": "^0.28.5",
                 "typedoc-plugin-markdown": "^4.4.1",
-                "typescript": "^5.7.3",
-                "wasm-opt": "^1.4.0"
+                "typescript": "^5.7.3"
             },
             "engines": {
                 "node": ">=20"
@@ -1889,16 +1888,6 @@
                 "fsevents": "~2.3.2"
             }
         },
-        "node_modules/chownr": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-            "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/chrome-trace-event": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
@@ -3130,32 +3119,6 @@
             },
             "engines": {
                 "node": ">=12"
-            }
-        },
-        "node_modules/fs-minipass": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-            "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "minipass": "^3.0.0"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/fs-minipass/node_modules/minipass": {
-            "version": "3.3.6",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/fs-then-native": {
@@ -4944,43 +4907,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/minipass": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-            "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/minizlib": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-            "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "minipass": "^3.0.0",
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/minizlib/node_modules/minipass": {
-            "version": "3.3.6",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/mkdirp": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -5187,27 +5113,6 @@
             "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/node-fetch": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "whatwg-url": "^5.0.0"
-            },
-            "engines": {
-                "node": "4.x || >=6.0.0"
-            },
-            "peerDependencies": {
-                "encoding": "^0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "encoding": {
-                    "optional": true
-                }
-            }
         },
         "node_modules/node-releases": {
             "version": "2.0.19",
@@ -6453,24 +6358,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/tar": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-            "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "chownr": "^2.0.0",
-                "fs-minipass": "^2.0.0",
-                "minipass": "^5.0.0",
-                "minizlib": "^2.1.1",
-                "mkdirp": "^1.0.3",
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/temp-path": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/temp-path/-/temp-path-1.0.0.tgz",
@@ -6725,13 +6612,6 @@
             "engines": {
                 "node": ">=16"
             }
-        },
-        "node_modules/tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/tree-kill": {
             "version": "1.2.2",
@@ -7342,21 +7222,6 @@
                 "node": ">=12.17"
             }
         },
-        "node_modules/wasm-opt": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/wasm-opt/-/wasm-opt-1.4.0.tgz",
-            "integrity": "sha512-wIsxxp0/FOSphokH4VOONy1zPkVREQfALN+/JTvJPK8gFSKbsmrcfECu2hT7OowqPfb4WEMSMceHgNL0ipFRyw==",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "MIT",
-            "dependencies": {
-                "node-fetch": "^2.6.9",
-                "tar": "^6.1.13"
-            },
-            "bin": {
-                "wasm-opt": "bin/wasm-opt.js"
-            }
-        },
         "node_modules/watchpack": {
             "version": "2.4.4",
             "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.4.tgz",
@@ -7371,13 +7236,6 @@
             "engines": {
                 "node": ">=10.13.0"
             }
-        },
-        "node_modules/webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-            "dev": true,
-            "license": "BSD-2-Clause"
         },
         "node_modules/webpack": {
             "version": "5.100.2",
@@ -7501,17 +7359,6 @@
                 "url": "https://opencollective.com/webpack"
             }
         },
-        "node_modules/whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
-            }
-        },
         "node_modules/which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -7626,13 +7473,6 @@
             "engines": {
                 "node": ">=10"
             }
-        },
-        "node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "dev": true,
-            "license": "ISC"
         },
         "node_modules/yaml": {
             "version": "2.8.0",

--- a/bindings/wasm/hierarchies_wasm/package.json
+++ b/bindings/wasm/hierarchies_wasm/package.json
@@ -70,8 +70,7 @@
         "txm": "^8.1.0",
         "typedoc": "^0.28.5",
         "typedoc-plugin-markdown": "^4.4.1",
-        "typescript": "^5.7.3",
-        "wasm-opt": "^1.4.0"
+        "typescript": "^5.7.3"
     },
     "dependencies": {
         "@iota/iota-interaction-ts": "^0.14.0"


### PR DESCRIPTION
# Description of change

PR removes outdated `wasm-opt` installed via NPM, and add the requirement to have `wasm-opt` installed locally, which allows using newer versions, that are compatible with the latest Rust toolchain versions.

This updates the `wasm-opt` used in the build process to its latest version.

In related projects, we had an error related to newer Rust versions and outdated `wasm-opt` version (`[parse exception: invalid code after misc prefix: 17 (at ...)]`) thrown during build, which was fixed by the same changes. The error does not seem to be thrown at the moment (checked in CI), but possibly will have been with future changes in the code. Using an up-to-date `wasm-opt` version should prevent this.

## Links to any relevant issues

See [related issue](https://github.com/iotaledger/identity/issues/1811).

## Type of change

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix
- [x] Chore

## How the change has been tested

Same changes fixed `wasm-opt` error in identity project (see related issue above).

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation