### PR TITLE
Release: Version 0.1.20-alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2669,7 +2669,7 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hierarchies"
-version = "0.1.19-alpha"
+version = "0.1.20-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "hierarchies_examples"
-version = "0.1.19-alpha"
+version = "0.1.20-alpha"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["hierarchies-rs/examples", "hierarchies-rs/hierarchies"]
 exclude = ["bindings/wasm/hierarchies_wasm"]
 
 [workspace.package]
-version = "0.1.19-alpha"
+version = "0.1.20-alpha"
 authors = ["IOTA Stiftung"]
 edition = "2024"
 homepage = "https://www.iota.org"

--- a/bindings/wasm/hierarchies_wasm/Cargo.toml
+++ b/bindings/wasm/hierarchies_wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hierarchies_wasm"
-version = "0.1.19-alpha"
+version = "0.1.20-alpha"
 authors = ["IOTA Stiftung"]
 edition = "2024"
 homepage = "https://www.iota.org"


### PR DESCRIPTION
# Description of change
Bump cargo versions for Hieararchies to `0.1.20-alpha`